### PR TITLE
Expose is24Hour to props

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ export default class DateTimePickerTester extends Component {
 | titleIOS | string | 'Pick a date' | The title text on iOS |
 | minimumDate | Date | undefined | Min Date
 | maximumDate | Date | undefined | Max Date
+| is24Hour | bool | true | If false, the picker shows an AM/PM chooser on Android |
 
 All the [DatePickerIOS props](https://facebook.github.io/react-native/docs/datepickerios.html) are also supported!  
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-modal-datetime-picker",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A react-native datetime-picker for Android and iOS",
   "main": "src/index.js",
   "scripts": {

--- a/src/CustomDatePickerAndroid/index.js
+++ b/src/CustomDatePickerAndroid/index.js
@@ -8,6 +8,7 @@ export default class CustomDatePickerAndroid extends Component {
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onCancel: PropTypes.func.isRequired,
     onConfirm: PropTypes.func.isRequired,
+    is24Hour: PropTypes.bool,
     isVisible: PropTypes.bool,
     minimumDate: PropTypes.instanceOf(Date),
     maximumDate: PropTypes.instanceOf(Date)
@@ -16,6 +17,7 @@ export default class CustomDatePickerAndroid extends Component {
   static defaultProps = {
     date: new Date(),
     mode: 'date',
+    is24Hour: true,
     isVisible: false
   }
 
@@ -68,7 +70,7 @@ export default class CustomDatePickerAndroid extends Component {
       const { action, hour, minute } = await TimePickerAndroid.open({
         hour: moment(this.props.date).hour(),
         minute: moment(this.props.date).minute(),
-        is24Hour: true
+        is24Hour: this.props.is24Hour
       })
       if (action !== TimePickerAndroid.dismissedAction) {
         const date = moment({ hour, minute }).toDate()


### PR DESCRIPTION
This will allow folks to have the option of showing an AM/PM picker on Android by setting the prop:
``is24Hour={false}``