### PR TITLE
Improve package.json by adding homepage and repository keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
   ],
   "author": "Mazzarolo Matteo",
   "license": "ISC",
+  "homepage": "https://github.com/mmazzarolo/react-native-modal-datetime-picker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mmazzarolo/react-native-modal-datetime-picker"
+  },
   "dependencies": {
     "moment": "^2.18.1",
     "react-native-modal": "^2.2.0"


### PR DESCRIPTION
Hi,
i have added the keys [repository](https://docs.npmjs.com/files/package.json#repository) and [homepage](https://docs.npmjs.com/files/package.json#homepage) to the `package.json` file.

These keys are used at various places.

For example, a link to the github page will appear on the [npm package details page](https://www.npmjs.com/package/react-native-modal-datetime-picker).

It is very useful too, if you are using `yarn outdated`. If there is a new version of your package you can directly click on the provided url (the github page). So it is easy to check for new features or breaking changes.

Keep up your good work!