### PR TITLE
Use new ViewPropTypes instead of deprecated View.propTypes

### DIFF
--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { DatePickerIOS, Text, TouchableOpacity, View } from 'react-native';
+import { DatePickerIOS, Text, TouchableOpacity, View, ViewPropTypes } from 'react-native';
 import ReactNativeModal from 'react-native-modal';
 
 import styles from './index.style';
@@ -11,7 +11,7 @@ export default class CustomDatePickerIOS extends Component {
     customCancelButtonIOS: PropTypes.node,
     customConfirmButtonIOS: PropTypes.node,
     customTitleContainerIOS: PropTypes.node,
-    datePickerContainerStyleIOS: View.propTypes.style,
+    datePickerContainerStyleIOS: ViewPropTypes.style,
     date: PropTypes.instanceOf(Date),
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onConfirm: PropTypes.func.isRequired,


### PR DESCRIPTION
Hi again,
in newest react-native version (0.44) `View.propTypes` is deprecated. So i've changed it to use the new provided `ViewPropTypes` to get rid of the deprecation warning.

Be careful when merging, maybe using ViewPropTypes will break backward compatibility with older react-native versions.

Some other libraries have changed the code to `PropTypes.any` instead of using the new `ViewPropTypes`.

What do you think about this?

Keep up your good work!