### PR TITLE
Added onHideAfterConfirm

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ export default class DateTimePickerTester extends Component {
 | mode | string | 'date' | Datepicker? 'date' Timepicker? 'time' Both? 'datetime' |
 | datePickerModeAndroid | string | 'calendar' | Display as 'spinner' or 'calendar'|
 | onConfirm | func | **REQUIRED** | Function called on date picked |
-| onHideAfterConfirm | func | () => {} | Function called after the hiding animation after date picked |
+| onHideAfterConfirm | func | () => {} | Called after the hiding animation if a date was picked |
 | onCancel | func | **REQUIRED** |  Function called on dismiss |
 | titleIOS | string | 'Pick a date' | The title text on iOS |
 | minimumDate | Date | undefined | Min Date

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ export default class DateTimePickerTester extends Component {
 | mode | string | 'date' | Datepicker? 'date' Timepicker? 'time' Both? 'datetime' |
 | datePickerModeAndroid | string | 'calendar' | Display as 'spinner' or 'calendar'|
 | onConfirm | func | **REQUIRED** | Function called on date picked |
+| onHideAfterConfirm | func | () => {} | Function called after the hiding animation after date picked |
 | onCancel | func | **REQUIRED** |  Function called on dismiss |
 | titleIOS | string | 'Pick a date' | The title text on iOS |
 | minimumDate | Date | undefined | Min Date

--- a/src/CustomDatePickerAndroid/index.js
+++ b/src/CustomDatePickerAndroid/index.js
@@ -8,7 +8,7 @@ export default class CustomDatePickerAndroid extends Component {
     date: PropTypes.instanceOf(Date),
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onCancel: PropTypes.func.isRequired,
-    onConfirmAfterAnimation: PropTypes.func,
+    onHideAfterConfirm: PropTypes.func,
     onConfirm: PropTypes.func.isRequired,
     is24Hour: PropTypes.bool,
     isVisible: PropTypes.bool,
@@ -23,7 +23,7 @@ export default class CustomDatePickerAndroid extends Component {
     datePickerModeAndroid: 'calendar',
     is24Hour: true,
     isVisible: false,
-    onConfirmAfterAnimation: () => {},    
+    onHideAfterConfirm: () => {},    
   };
 
   componentDidUpdate = prevProps => {

--- a/src/CustomDatePickerAndroid/index.js
+++ b/src/CustomDatePickerAndroid/index.js
@@ -8,8 +8,8 @@ export default class CustomDatePickerAndroid extends Component {
     date: PropTypes.instanceOf(Date),
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onCancel: PropTypes.func.isRequired,
-    onHideAfterConfirm: PropTypes.func,
     onConfirm: PropTypes.func.isRequired,
+    onHideAfterConfirm: PropTypes.func,
     is24Hour: PropTypes.bool,
     isVisible: PropTypes.bool,
     datePickerModeAndroid: PropTypes.oneOf(['calendar', 'spinner', 'default']),
@@ -57,12 +57,14 @@ export default class CustomDatePickerAndroid extends Component {
             if (timeAction !== TimePickerAndroid.dismissedAction) {
               const selectedDate = new Date(year, month, day, hour, minute);
               this.props.onConfirm(selectedDate);
+              this.props.onHideAfterConfirm(selectedDate);
             } else {
               this.props.onCancel();
             }
           });
         } else {
           this.props.onConfirm(date);
+          this.props.onHideAfterConfirm(date);
         }
       } else {
         this.props.onCancel();
@@ -82,6 +84,7 @@ export default class CustomDatePickerAndroid extends Component {
       if (action !== TimePickerAndroid.dismissedAction) {
         const date = moment({ hour, minute }).toDate();
         this.props.onConfirm(date);
+        this.props.onHideAfterConfirm(date);
       } else {
         this.props.onCancel();
       }

--- a/src/CustomDatePickerAndroid/index.js
+++ b/src/CustomDatePickerAndroid/index.js
@@ -8,6 +8,7 @@ export default class CustomDatePickerAndroid extends Component {
     date: PropTypes.instanceOf(Date),
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onCancel: PropTypes.func.isRequired,
+    onModalHide: PropTypes.func,
     onConfirm: PropTypes.func.isRequired,
     is24Hour: PropTypes.bool,
     isVisible: PropTypes.bool,
@@ -22,6 +23,7 @@ export default class CustomDatePickerAndroid extends Component {
     datePickerModeAndroid: 'calendar',
     is24Hour: true,
     isVisible: false,
+    onModalHide: () => {},    
   };
 
   componentDidUpdate = prevProps => {
@@ -57,6 +59,7 @@ export default class CustomDatePickerAndroid extends Component {
               this.props.onConfirm(selectedDate);
             } else {
               this.props.onCancel();
+              this.props.onModalHide();
             }
           });
         } else {
@@ -64,6 +67,7 @@ export default class CustomDatePickerAndroid extends Component {
         }
       } else {
         this.props.onCancel();
+        this.props.onModalHide();
       }
     } catch ({ code, message }) {
       console.warn('Cannot open date picker', message);
@@ -82,6 +86,7 @@ export default class CustomDatePickerAndroid extends Component {
         this.props.onConfirm(date);
       } else {
         this.props.onCancel();
+        this.props.onModalHide();
       }
     } catch ({ code, message }) {
       console.warn('Cannot open time picker', message);

--- a/src/CustomDatePickerAndroid/index.js
+++ b/src/CustomDatePickerAndroid/index.js
@@ -8,7 +8,7 @@ export default class CustomDatePickerAndroid extends Component {
     date: PropTypes.instanceOf(Date),
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onCancel: PropTypes.func.isRequired,
-    onModalHide: PropTypes.func,
+    onConfirmAfterAnimation: PropTypes.func,
     onConfirm: PropTypes.func.isRequired,
     is24Hour: PropTypes.bool,
     isVisible: PropTypes.bool,
@@ -23,7 +23,7 @@ export default class CustomDatePickerAndroid extends Component {
     datePickerModeAndroid: 'calendar',
     is24Hour: true,
     isVisible: false,
-    onModalHide: () => {},    
+    onConfirmAfterAnimation: () => {},    
   };
 
   componentDidUpdate = prevProps => {
@@ -59,7 +59,6 @@ export default class CustomDatePickerAndroid extends Component {
               this.props.onConfirm(selectedDate);
             } else {
               this.props.onCancel();
-              this.props.onModalHide();
             }
           });
         } else {
@@ -67,7 +66,6 @@ export default class CustomDatePickerAndroid extends Component {
         }
       } else {
         this.props.onCancel();
-        this.props.onModalHide();
       }
     } catch ({ code, message }) {
       console.warn('Cannot open date picker', message);
@@ -86,7 +84,6 @@ export default class CustomDatePickerAndroid extends Component {
         this.props.onConfirm(date);
       } else {
         this.props.onCancel();
-        this.props.onModalHide();
       }
     } catch ({ code, message }) {
       console.warn('Cannot open time picker', message);

--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -17,8 +17,8 @@ export default class CustomDatePickerIOS extends Component {
     date: PropTypes.instanceOf(Date),
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onConfirm: PropTypes.func.isRequired,
-    onCancel: PropTypes.func.isRequired,
     onHideAfterConfirm: PropTypes.func,
+    onCancel: PropTypes.func.isRequired,
     titleIOS: PropTypes.string,
     isVisible: PropTypes.bool,
   };

--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -18,6 +18,7 @@ export default class CustomDatePickerIOS extends Component {
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onConfirm: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
+    onModalHide: PropTypes.func,
     titleIOS: PropTypes.string,
     isVisible: PropTypes.bool,
   };
@@ -29,6 +30,7 @@ export default class CustomDatePickerIOS extends Component {
     mode: 'date',
     titleIOS: 'Pick a date',
     isVisible: false,
+    onModalHide: () => {},
   };
 
   state = {
@@ -63,6 +65,7 @@ export default class CustomDatePickerIOS extends Component {
   render() {
     const {
       onCancel,
+      onModalHide,
       isVisible,
       mode,
       titleIOS,
@@ -103,7 +106,10 @@ export default class CustomDatePickerIOS extends Component {
     }
     const cancelButton = <Text style={styles.cancelText}>{cancelTextIOS}</Text>;
     return (
-      <ReactNativeModal isVisible={isVisible} style={styles.contentContainer}>
+      <ReactNativeModal
+        isVisible={isVisible}
+        style={styles.contentContainer}
+        onModalHide={onModalHide}>
         <View style={[styles.datepickerContainer, datePickerContainerStyleIOS]}>
           {customTitleContainerIOS || titleContainer}
           <View onStartShouldSetResponderCapture={this._handleUserTouchInit}>

--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -18,7 +18,7 @@ export default class CustomDatePickerIOS extends Component {
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onConfirm: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
-    onModalHide: PropTypes.func,
+    onConfirmAfterAnimation: PropTypes.func,
     titleIOS: PropTypes.string,
     isVisible: PropTypes.bool,
   };
@@ -30,7 +30,7 @@ export default class CustomDatePickerIOS extends Component {
     mode: 'date',
     titleIOS: 'Pick a date',
     isVisible: false,
-    onModalHide: () => {},
+    onConfirmAfterAnimation: () => {},
   };
 
   state = {
@@ -47,6 +47,10 @@ export default class CustomDatePickerIOS extends Component {
   }
 
   _handleConfirm = () => this.props.onConfirm(this.state.date);
+
+  _handleOnModalHide = () => {
+    this.props.onConfirmAfterAnimation(this.state.date);
+  }
 
   _handleDateChange = date => {
     this.setState({
@@ -65,7 +69,7 @@ export default class CustomDatePickerIOS extends Component {
   render() {
     const {
       onCancel,
-      onModalHide,
+      onConfirmAfterAnimation,
       isVisible,
       mode,
       titleIOS,
@@ -109,7 +113,7 @@ export default class CustomDatePickerIOS extends Component {
       <ReactNativeModal
         isVisible={isVisible}
         style={styles.contentContainer}
-        onModalHide={onModalHide}>
+        onModalHide={this._handleOnModalHide}>
         <View style={[styles.datepickerContainer, datePickerContainerStyleIOS]}>
           {customTitleContainerIOS || titleContainer}
           <View onStartShouldSetResponderCapture={this._handleUserTouchInit}>

--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -18,7 +18,7 @@ export default class CustomDatePickerIOS extends Component {
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onConfirm: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
-    onConfirmAfterAnimation: PropTypes.func,
+    onHideAfterConfirm: PropTypes.func,
     titleIOS: PropTypes.string,
     isVisible: PropTypes.bool,
   };
@@ -30,7 +30,7 @@ export default class CustomDatePickerIOS extends Component {
     mode: 'date',
     titleIOS: 'Pick a date',
     isVisible: false,
-    onConfirmAfterAnimation: () => {},
+    onHideAfterConfirm: () => {},
   };
 
   state = {
@@ -49,7 +49,7 @@ export default class CustomDatePickerIOS extends Component {
   _handleConfirm = () => this.props.onConfirm(this.state.date);
 
   _handleOnModalHide = () => {
-    this.props.onConfirmAfterAnimation(this.state.date);
+    this.props.onHideAfterConfirm(this.state.date);
   }
 
   _handleDateChange = date => {
@@ -69,7 +69,6 @@ export default class CustomDatePickerIOS extends Component {
   render() {
     const {
       onCancel,
-      onConfirmAfterAnimation,
       isVisible,
       mode,
       titleIOS,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -142,7 +142,7 @@ interface DateTimePickerProps {
      * Called when the underlying modal finishes its' closing animation
      * after Confirm was pressed.
      */
-    onConfirmAfterAnimation(date: Date): void
+    onHideAfterConfirm(date: Date): void
 }
 
 export default class DateTimePicker extends React.Component<DateTimePickerProps, any> { }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -139,9 +139,10 @@ interface DateTimePickerProps {
 
 
     /**
-     * Called when the underlying modal finishes its' closing animation.
+     * Called when the underlying modal finishes its' closing animation
+     * after Confirm was pressed.
      */
-    onModalHide(): void
+    onConfirmAfterAnimation(date: Date): void
 }
 
 export default class DateTimePicker extends React.Component<DateTimePickerProps, any> { }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -136,6 +136,12 @@ interface DateTimePickerProps {
      * Passes the current selected date
      */
     onCancel(date: Date): void
+
+
+    /**
+     * Called when the underlying modal finishes its' closing animation.
+     */
+    onModalHide(): void
 }
 
 export default class DateTimePicker extends React.Component<DateTimePickerProps, any> { }


### PR DESCRIPTION
I'm using react-native-modal-datetime-picker in a search where changing the date may make the modified result disappear. Everything worked fine, until I started getting warnings for calling setState on an unmounted component.

It turned out that the animation was still running when I refreshed my search, so when the animation was done the component had already unmounted.

The solution was to wait for the animation using **onHideAfterConfirm**.

It works for me, so I though I'd share it.