### PR TITLE
Change default value of datePickerModeAndroid

### DIFF
--- a/src/CustomDatePickerAndroid/index.js
+++ b/src/CustomDatePickerAndroid/index.js
@@ -20,7 +20,7 @@ export default class CustomDatePickerAndroid extends Component {
   static defaultProps = {
     date: new Date(),
     mode: 'date',
-    datePickerModeAndroid: 'calendar',
+    datePickerModeAndroid: 'default',
     is24Hour: true,
     isVisible: false,
     onHideAfterConfirm: () => {},


### PR DESCRIPTION
This PR changes the default value of `datePickerModeAndroid` to `'default'`, to prevent an [issue](https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/29) related to changing the style of the date and time pickers on Android.