### PR TITLE
Fix typo that causes hour to be unset in Android datetime picker

### DIFF
--- a/src/CustomDatePickerAndroid/index.js
+++ b/src/CustomDatePickerAndroid/index.js
@@ -51,7 +51,7 @@ export default class CustomDatePickerAndroid extends Component {
           // Prepopulate and show time picker
           const timeOptions = {is24Hour: this.props.is24Hour};
           if (this.props.date) {
-            timeOptions.hours = this.props.date.getHours();
+            timeOptions.hour = this.props.date.getHours();
             timeOptions.minute = this.props.date.getMinutes();
           }
           const { action: timeAction, hour, minute } = await TimePickerAndroid.open(timeOptions);

--- a/src/CustomDatePickerAndroid/index.js
+++ b/src/CustomDatePickerAndroid/index.js
@@ -51,8 +51,8 @@ export default class CustomDatePickerAndroid extends Component {
           // Prepopulate and show time picker
           const timeOptions = {is24Hour: this.props.is24Hour};
           if (this.props.date) {
-            timeOptions.hour = this.props.date.getHours();
-            timeOptions.minute = this.props.date.getMinutes();
+            timeOptions.hour = moment(this.props.date).hour();
+            timeOptions.minute = moment(this.props.date).minute();
           }
           const { action: timeAction, hour, minute } = await TimePickerAndroid.open(timeOptions);
           if (timeAction !== TimePickerAndroid.dismissedAction) {


### PR DESCRIPTION
There's a small typo in Android's date picker while in "datetime" mode that causes the hour to be ignored from the "date" prop. I also moved this code to use `moment` since this was used in the time picker. This keeps consistency across the code.