### PR TITLE
Fix TypeScript typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // TypeScript Version: 2.3.2
 
-import React from 'react'
+import * as React from 'react'
 import { ViewStyle } from 'react-native'
 
 interface DateTimePickerProps {


### PR DESCRIPTION
I'm not sure why it wasn't like this but typescript needs it to be like this in order to work. Without this change it just gives errors.