### PR TITLE
add a new prop: neverDisableConfirmIOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ export default class DateTimePickerTester extends Component {
 | confirmTextStyle | style |  | The style of the confirm button text on iOS |
 | customCancelButtonIOS | node |  | A custom component for the cancel button on iOS |
 | customConfirmButtonIOS | node |  | A custom component for the confirm button on iOS |
+| neverDisableConfirmIOS | bool | false | If true, do not disable the confirm button on any touch events; see [#82](https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/82) |
 | customTitleContainerIOS | node |  | A custom component for the title container on iOS |
 | datePickerContainerStyleIOS | style |  | The style of the container on iOS |
 | reactNativeModalPropsIOS | object |  | Additional props for [react-native-modal](https://github.com/react-native-community/react-native-modal) on iOS |

--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -11,6 +11,7 @@ export default class CustomDatePickerIOS extends Component {
     confirmTextIOS: PropTypes.string,
     customCancelButtonIOS: PropTypes.node,
     customConfirmButtonIOS: PropTypes.node,
+    neverDisableConfirmIOS: PropTypes.bool,
     customConfirmButtonWhileInteractingIOS: PropTypes.node,
     customTitleContainerIOS: PropTypes.node,
     contentContainerStyleIOS: PropTypes.any,
@@ -29,6 +30,7 @@ export default class CustomDatePickerIOS extends Component {
   };
 
   static defaultProps = {
+    neverDisableConfirmIOS: false,
     cancelTextIOS: 'Cancel',
     confirmTextIOS: 'Confirm',
     date: new Date(),
@@ -91,6 +93,7 @@ export default class CustomDatePickerIOS extends Component {
       cancelTextIOS,
       customCancelButtonIOS,
       customConfirmButtonIOS,
+      neverDisableConfirmIOS,
       customConfirmButtonWhileInteractingIOS,
       contentContainerStyleIOS,
       customTitleContainerIOS,
@@ -150,7 +153,7 @@ export default class CustomDatePickerIOS extends Component {
             style={styles.confirmButton}
             underlayColor='#ebebeb'
             onPress={this._handleConfirm}
-            disabled={this.state.userIsInteractingWithPicker}
+            disabled={!neverDisableConfirmIOS && this.state.userIsInteractingWithPicker}
           >
             {confirmButton}
           </TouchableHighlight>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,6 +30,13 @@ interface DateTimePickerProps {
      * A custom component for the confirm button on iOS
      */
     customConfirmButtonIOS?: JSX.Element
+    
+    /**
+     * Never disable the confirm button on iOS, even on fling (see #82)
+     *
+     * Default is false
+     */
+     neverDisableConfirmIOS?: boolean
 
     /**
      * A custom component for the title container on iOS


### PR DESCRIPTION
add a new prop -- neverDisableConfirmIOS -- that prevents disabling the confirm button on ios picker wheel

see #82 