### PR TITLE
Allow `date` prop to be a Date or `moment` instance

### DIFF
--- a/src/CustomDatePickerAndroid/index.js
+++ b/src/CustomDatePickerAndroid/index.js
@@ -5,7 +5,10 @@ import moment from 'moment';
 
 export default class CustomDatePickerAndroid extends Component {
   static propTypes = {
-    date: PropTypes.instanceOf(Date),
+    date: PropTypes.oneOfType([
+      PropTypes.instanceOf(Date),
+      PropTypes.instanceOf(moment),
+    ]),
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onCancel: PropTypes.func.isRequired,
     onConfirm: PropTypes.func.isRequired,

--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -16,7 +16,10 @@ export default class CustomDatePickerIOS extends Component {
     customTitleContainerIOS: PropTypes.node,
     contentContainerStyleIOS: PropTypes.any,
     datePickerContainerStyleIOS: PropTypes.any,
-    date: PropTypes.instanceOf(Date),
+    date: PropTypes.oneOfType([
+      PropTypes.instanceOf(Date),
+      PropTypes.instanceOf(moment),
+    ]),
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onConfirm: PropTypes.func.isRequired,
     onHideAfterConfirm: PropTypes.func,


### PR DESCRIPTION
Allowing the `date` prop to be a `moment` instance removes some boilerplate coercion for people using this common date library.