### PR TITLE
We can now use a custom DatePicker component

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ export default class DateTimePickerTester extends Component {
 | customConfirmButtonIOS | node |  | A custom component for the confirm button on iOS |
 | neverDisableConfirmIOS | bool | false | If true, do not disable the confirm button on any touch events; see [#82](https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/82) |
 | customTitleContainerIOS | node |  | A custom component for the title container on iOS |
-| customDatePickerIOS | node |  | A custom component that will replace the default DatePicker on iOS|
+| customDatePickerIOS | node |  | A custom component that will replace the default DatePicker on iOS [(Example)](https://github.com/mmazzarolo/react-native-modal-datetime-picker/pull/115#issue-279547697)|
 | datePickerContainerStyleIOS | style |  | The style of the container on iOS |
 | reactNativeModalPropsIOS | object |  | Additional props for [react-native-modal](https://github.com/react-native-community/react-native-modal) on iOS |
 | date | obj | new Date() | Initial selected date/time |

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ export default class DateTimePickerTester extends Component {
 | customConfirmButtonIOS | node |  | A custom component for the confirm button on iOS |
 | neverDisableConfirmIOS | bool | false | If true, do not disable the confirm button on any touch events; see [#82](https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/82) |
 | customTitleContainerIOS | node |  | A custom component for the title container on iOS |
+| customDatePickerIOS | node |  | A custom component that will replace the default DatePicker on iOS|
 | datePickerContainerStyleIOS | style |  | The style of the container on iOS |
 | reactNativeModalPropsIOS | object |  | Additional props for [react-native-modal](https://github.com/react-native-community/react-native-modal) on iOS |
 | date | obj | new Date() | Initial selected date/time |
@@ -81,6 +82,7 @@ export default class DateTimePickerTester extends Component {
 | datePickerModeAndroid | string | 'calendar' | Display as 'spinner' or 'calendar'|
 | onConfirm | func | **REQUIRED** | Function called on date picked |
 | onHideAfterConfirm | func | () => {} | Called after the hiding animation if a date was picked |
+| pickerRefCb | func |  | Called after picker has mounted, contains a ref |
 | onCancel | func | **REQUIRED** |  Function called on dismiss |
 | titleIOS | string | 'Pick a date' | The title text on iOS |
 | titleStyle | style |  | The style of the title text on iOS |

--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -83,9 +83,12 @@ export default class CustomDatePickerIOS extends Component {
   };
 
   _handleUserTouchInit = () => {
-    this.setState({
-      userIsInteractingWithPicker: true,
-    });
+    // custom date picker shouldn't change this param
+    if(!customDatePickerIOS){
+      this.setState({
+        userIsInteractingWithPicker: true,
+      })
+    }
     return false;
   };
 

--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -14,12 +14,17 @@ export default class CustomDatePickerIOS extends Component {
     neverDisableConfirmIOS: PropTypes.bool,
     customConfirmButtonWhileInteractingIOS: PropTypes.node,
     customTitleContainerIOS: PropTypes.node,
+    customDatePickerIOS: PropTypes.oneOfType([
+      PropTypes.node,
+      PropTypes.func,
+    ]),
     contentContainerStyleIOS: PropTypes.any,
     datePickerContainerStyleIOS: PropTypes.any,
     date: PropTypes.instanceOf(Date),
     mode: PropTypes.oneOf(['date', 'time', 'datetime']),
     onConfirm: PropTypes.func.isRequired,
     onHideAfterConfirm: PropTypes.func,
+    pickerRefCb: PropTypes.func,
     onCancel: PropTypes.func.isRequired,
     titleIOS: PropTypes.string,
     isVisible: PropTypes.bool,
@@ -95,6 +100,7 @@ export default class CustomDatePickerIOS extends Component {
       customConfirmButtonIOS,
       neverDisableConfirmIOS,
       customConfirmButtonWhileInteractingIOS,
+      customDatePickerIOS,
       contentContainerStyleIOS,
       customTitleContainerIOS,
       datePickerContainerStyleIOS,
@@ -103,6 +109,7 @@ export default class CustomDatePickerIOS extends Component {
       titleStyle,
       confirmTextStyle,
       cancelTextStyle,
+      pickerRefCb,
       ...otherProps
     } = this.props;
 
@@ -122,7 +129,9 @@ export default class CustomDatePickerIOS extends Component {
     // We no longer allow our user to tap the confirm button unless the picker is still.
     // They can always tap the cancel button anyway.
     if (customConfirmButtonIOS) {
-      if (customConfirmButtonWhileInteractingIOS && this.state.userIsInteractingWithPicker) {
+      if (customConfirmButtonWhileInteractingIOS
+        && this.state.userIsInteractingWithPicker
+      ) {
         confirmButton = customConfirmButtonWhileInteractingIOS;
       } else {
         confirmButton = customConfirmButtonIOS;
@@ -131,6 +140,8 @@ export default class CustomDatePickerIOS extends Component {
       confirmButton = <Text style={[styles.confirmText, confirmTextStyle]}>{confirmTextIOS}</Text>;
     }
     const cancelButton = <Text style={[styles.cancelText, cancelTextStyle]}>{cancelTextIOS}</Text>;
+    const DatePickerComponent = customDatePickerIOS || DatePickerIOS;
+    
     return (
       <ReactNativeModal
         isVisible={isVisible}
@@ -141,8 +152,9 @@ export default class CustomDatePickerIOS extends Component {
       >
         <View style={[styles.datepickerContainer, datePickerContainerStyleIOS]}>
           {customTitleContainerIOS || titleContainer}
-          <View onStartShouldSetResponderCapture={this._handleUserTouchInit}>
-            <DatePickerIOS
+          <View onStartShouldSetResponderCapture={neverDisableConfirmIOS !== true ? this._handleUserTouchInit : null}>
+            <DatePickerComponent
+              ref={pickerRefCb}
               date={this.state.date}
               mode={mode}
               onDateChange={this._handleDateChange}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,6 +44,12 @@ interface DateTimePickerProps {
     customTitleContainerIOS?: JSX.Element
 
     /**
+     * A custom component that will replace the default DatePicker on iOS
+     */
+    customDatePickerIOS?: JSX.Element
+
+    
+    /**
      * The style of the container on iOS
      */
     datePickerContainerStyleIOS?: ViewStyle


### PR DESCRIPTION
Need this to be able to replace DatePickerIOS w/ something like dgladkov/react-native-uncontrolled-date-picker-ios

Usage:

```javascript
<TimerPicker
	pickerRefCb={(datePicker) => { this.datepickerRef = datePicker; }}
	customDatePickerIOS={Platform.OS === 'ios' ? UncontrolledDatePickerIOS : null}
	onConfirm={() => {
		if (this.datepickerRef && this.datepickerRef.getDate) {
			this.datepickerRef.getDate((datePicked) => {
				// do something with the datePicked Date obj
			});
		}
	}}
/>
```