### PR TITLE
Allow displaying the picker on mount (Android)

### DIFF
--- a/src/CustomDatePickerAndroid/index.js
+++ b/src/CustomDatePickerAndroid/index.js
@@ -36,6 +36,16 @@ export default class CustomDatePickerAndroid extends PureComponent {
     }
   };
 
+  componentDidMount = () => {
+    if (this.props && this.props.isVisible) {
+      if (this.props.mode === 'date' || this.props.mode === 'datetime') {
+        this._showDatePickerAndroid();
+      } else {
+        this._showTimePickerAndroid();
+      }
+    }
+  };
+
   _showDatePickerAndroid = async () => {
     try {
       const { action, year, month, day } = await DatePickerAndroid.open({


### PR DESCRIPTION
Handle props on componentDidMount() to allow displaying the picker on component mount.