### PR TITLE
Add ability to pass params to onConfirm function.

### DIFF
--- a/src/CustomDatePickerAndroid/index.js
+++ b/src/CustomDatePickerAndroid/index.js
@@ -74,13 +74,13 @@ export default class CustomDatePickerAndroid extends PureComponent {
           const { action: timeAction, hour, minute } = await TimePickerAndroid.open(timeOptions);
           if (timeAction !== TimePickerAndroid.dismissedAction) {
             const selectedDate = new Date(year, month, day, hour, minute);
-            this.props.onConfirm(selectedDate);
+            this.props.onConfirm(selectedDate, this.props.params);
             this.props.onHideAfterConfirm(selectedDate);
           } else {
             this.props.onCancel();
           }
         } else {
-          this.props.onConfirm(date);
+          this.props.onConfirm(date, this.props.params);
           this.props.onHideAfterConfirm(date);
         }
       } else {
@@ -109,7 +109,7 @@ export default class CustomDatePickerAndroid extends PureComponent {
         } else {
           date = moment({ hour, minute }).toDate();
         }
-        this.props.onConfirm(date);
+        this.props.onConfirm(date, this.props.params);
         this.props.onHideAfterConfirm(date);
       } else {
         this.props.onCancel();

--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -62,7 +62,7 @@ export default class CustomDatePickerIOS extends PureComponent {
 
   _handleConfirm = () => {
     this.confirmed = true;
-    this.props.onConfirm(this.state.date);
+    this.props.onConfirm(this.state.date, this.props.params);
   };
 
   _handleOnModalHide = () => {


### PR DESCRIPTION
This is useful if you have a list of date fields and need to pass argument(s) to the onConfirm function, like an id, in order to do something when a date is selected.