### PR TITLE
Fixes issue #161 - Differing behavior between iOS and Android 

### DIFF
--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -42,7 +42,7 @@ export default class CustomDatePickerIOS extends React.PureComponent {
     isVisible: false,
     onHideAfterConfirm: () => {},
     reactNativeModalPropsIOS: {},
-    onDateChange: () => {},
+    onDateChange: () => {}
   };
 
   state = {
@@ -62,11 +62,19 @@ export default class CustomDatePickerIOS extends React.PureComponent {
   _handleCancel = () => {
     this.confirmed = false;
     this.props.onCancel();
+    this._resetDate();
   };
 
   _handleConfirm = () => {
     this.confirmed = true;
     this.props.onConfirm(this.state.date);
+    this._resetDate();
+  };
+
+  _resetDate = () => {
+    this.setState({
+      date: new Date()
+    });
   };
 
   _handleOnModalHide = () => {


### PR DESCRIPTION
This PR aims to fix the issue #161 

- By resetting the localState of date to new Date() on confirmation or cancelation of the modal window solves the issue