### PR TITLE
Fix - minuteInterval should take value from props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ android/keystores/debug.keystore
 .jsconfig.json
 .vscode
 jsconfig.json
+npm-debug.log.*

--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -48,7 +48,7 @@ export default class CustomDatePickerIOS extends React.PureComponent {
   state = {
     date: this.props.date,
     userIsInteractingWithPicker: false,
-    minuteInterval: 1
+    minuteInterval: this.props.minuteInterval || 1
   };
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
while initializing the state for minuteInterval, Use the values passed from props, if undefined then use '1' as a fallback 

This fixes issue https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/158