### PR TITLE
Add hideTitleContainerIOS prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ export default class DateTimePickerTester extends Component {
 | customConfirmButtonIOS | node |  | A custom component for the confirm button on iOS |
 | neverDisableConfirmIOS | bool | false | If true, do not disable the confirm button on any touch events; see [#82](https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/82) |
 | customTitleContainerIOS | node |  | A custom component for the title container on iOS |
+| hideTitleContainerIOS | bool | false | If true, hide the modal title container on iOS |
 | customDatePickerIOS | node |  | A custom component that will replace the default DatePicker on iOS [(Example)](https://github.com/mmazzarolo/react-native-modal-datetime-picker/pull/115#issue-279547697)|
 | datePickerContainerStyleIOS | style |  | The style of the container on iOS |
 | reactNativeModalPropsIOS | object |  | Additional props for [react-native-modal](https://github.com/react-native-community/react-native-modal) on iOS |

--- a/src/CustomDatePickerIOS/index.js
+++ b/src/CustomDatePickerIOS/index.js
@@ -14,6 +14,7 @@ export default class CustomDatePickerIOS extends React.PureComponent {
     neverDisableConfirmIOS: PropTypes.bool,
     customConfirmButtonWhileInteractingIOS: PropTypes.node,
     customTitleContainerIOS: PropTypes.node,
+    hideTitleContainerIOS: PropTypes.bool,
     customDatePickerIOS: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
     contentContainerStyleIOS: PropTypes.any,
     datePickerContainerStyleIOS: PropTypes.any,
@@ -34,6 +35,7 @@ export default class CustomDatePickerIOS extends React.PureComponent {
 
   static defaultProps = {
     neverDisableConfirmIOS: false,
+    hideTitleContainerIOS: false,
     cancelTextIOS: "Cancel",
     confirmTextIOS: "Confirm",
     date: new Date(),
@@ -115,6 +117,7 @@ export default class CustomDatePickerIOS extends React.PureComponent {
       customDatePickerIOS,
       contentContainerStyleIOS,
       customTitleContainerIOS,
+      hideTitleContainerIOS,
       datePickerContainerStyleIOS,
       reactNativeModalPropsIOS,
       titleStyle,
@@ -175,7 +178,7 @@ export default class CustomDatePickerIOS extends React.PureComponent {
         {...reactNativeModalPropsIOS}
       >
         <View style={[styles.datepickerContainer, datePickerContainerStyleIOS]}>
-          {customTitleContainerIOS || titleContainer}
+          {!hideTitleContainerIOS && (customTitleContainerIOS || titleContainer)}
           <View
             onStartShouldSetResponderCapture={
               neverDisableConfirmIOS !== true ? this._handleUserTouchInit : null

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -84,6 +84,13 @@ interface DateTimePickerProps {
      * A custom component for the title container on iOS
      */
     customTitleContainerIOS?: JSX.Element
+    
+    /**
+     * Hide the title container on iOS
+     *
+     * Default is false
+     */
+    hideTitleContainerIOS?: boolean
 
     /**
      * A custom component that will replace the default DatePicker on iOS


### PR DESCRIPTION
This optional boolean prop, when set to true, will cause the modal's
title container to not render.