### PR TITLE
Add timePickerModeAndroid prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ export default class DateTimePickerTester extends Component {
 | date | obj | new Date() | Initial selected date/time |
 | isVisible | bool | false | Show the datetime picker? |
 | mode | string | 'date' | Datepicker? 'date' Timepicker? 'time' Both? 'datetime' |
-| datePickerModeAndroid | string | 'calendar' | Display as 'spinner' or 'calendar'|
+| datePickerModeAndroid | string | 'default' | Display as 'spinner' or 'calendar' or 'default' (based on Android version)|
+| timePickerModeAndroid | string | 'default' | Display as 'spinner' or 'clock' or 'default' (based on Android version)|
 | onConfirm | func | **REQUIRED** | Function called on date or time picked. It returns the date or time as a JavaScript Date object |
 | onHideAfterConfirm | func | () => {} | Called after the hiding animation if a date was picked |
 | pickerRefCb | func |  | Called after picker has mounted, contains a ref |

--- a/src/CustomDatePickerAndroid/index.js
+++ b/src/CustomDatePickerAndroid/index.js
@@ -12,6 +12,7 @@ export default class CustomDatePickerAndroid extends React.PureComponent {
     is24Hour: PropTypes.bool,
     isVisible: PropTypes.bool,
     datePickerModeAndroid: PropTypes.oneOf(["calendar", "spinner", "default"]),
+    timePickerModeAndroid: PropTypes.oneOf(["clock", "spinner", "default"]),
     minimumDate: PropTypes.instanceOf(Date),
     maximumDate: PropTypes.instanceOf(Date)
   };
@@ -20,6 +21,7 @@ export default class CustomDatePickerAndroid extends React.PureComponent {
     date: new Date(),
     mode: "date",
     datePickerModeAndroid: "default",
+    timePickerModeAndroid: "default",
     is24Hour: true,
     isVisible: false,
     onHideAfterConfirm: () => {}
@@ -74,7 +76,7 @@ export default class CustomDatePickerAndroid extends React.PureComponent {
         // Prepopulate and show time picker
         const timeOptions = {
           is24Hour: this.props.is24Hour,
-          mode: this.props.datePickerModeAndroid
+          mode: this.props.timePickerModeAndroid
         };
         if (this.props.date) {
           timeOptions.hour = this.props.date.getHours();
@@ -113,7 +115,7 @@ export default class CustomDatePickerAndroid extends React.PureComponent {
         hour: this.props.date.getHours(),
         minute: this.props.date.getMinutes(),
         is24Hour: this.props.is24Hour,
-        mode: this.props.datePickerModeAndroid
+        mode: this.props.timePickerModeAndroid
       });
     } catch ({ message }) {
       console.warn("Cannot open time picker", message);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -144,9 +144,16 @@ interface DateTimePickerProps {
   /**
    * Toggles the date mode on Android between spinner and calendar views
    *
-   * Default is 'calendar'
+   * Default is 'default' which shows either spinner or calendar based on Android version
    */
-  datePickerModeAndroid?: "spinner" | "calendar";
+  datePickerModeAndroid?: "spinner" | "calendar" | "default";
+
+  /**
+   * Toggles the time mode on Android between spinner and clock views
+   *
+   * Default is 'default' which shows either spinner or clock based on Android version
+   */
+  timePickerModeAndroid?: "spinner" | "clock" | "default";
 
   /**
    * Title text for the Picker on iOS


### PR DESCRIPTION
Allow the user to control DatePickerAndroid.mode and TimePickerAndroid.mode independently as currently some values for datePickerModeAndroid (e.g. 'calendar') will cause the component to throw errors as the value is passed to both DatePickerAndroid.open() and TimePickerAndroid.open().