### PR TITLE
comparing dates by value instead of objects

### DIFF
--- a/src/CustomDatePickerIOS.js
+++ b/src/CustomDatePickerIOS.js
@@ -61,7 +61,7 @@ export default class CustomDatePickerIOS extends React.PureComponent {
   };
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.date !== nextProps.date) {
+    if (this.props.date.valueOf() !== nextProps.date.valueOf()) {
       this.setState({
         date: nextProps.date
       });


### PR DESCRIPTION
# Overview

Attempt to resolve this issue: https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/247

As it is, the comparison on componentWillUpdate will always return true for derived data, even if the dates are the same, because the object will be different.

# Test Plan

Run the example from referenced issue
