### PR TITLE
Overwrite state date when a maximum date exists and date on state is …

### DIFF
--- a/src/CustomDatePickerIOS.js
+++ b/src/CustomDatePickerIOS.js
@@ -67,6 +67,11 @@ export default class CustomDatePickerIOS extends React.PureComponent {
         date: nextProps.date
       });
     }
+    if(nextProps.maximumDate && (!this.state.date || this.state.date > nextProps.maximumDate)){
+      this.setState({
+        date: nextProps.maximumDate
+      });
+    }
   }
 
   handleCancel = () => {


### PR DESCRIPTION
Overwrite state date when a maximum date exists and date on state is null or greater than maximum.
# Overview

When the confirm button was pressed without interacting with the picker, the maximumDate was ignored. That is, the selector shows a value with the maximum restriction, but after confirming, today's date that is greater than the maximum was shown.

Now when the maximumDate property exists, the value of the date in the state is overwritten.
# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->
Set a maximumDate reestriction smaller than today.
Open the modal and press confirm without interact to picker.
