### PR TITLE
 🏷️ Update ModalProps types to exclude required props

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5,7 +5,10 @@
 
 import * as React from "react";
 import { ViewStyle, TextStyle } from "react-native";
-import { ModalProps as ReactNativeModalProps } from "react-native-modal";
+import { ModalProps } from "react-native-modal";
+
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type ReactNativeModalProps = Omit<ModalProps, "children" | "isVisible">;
 
 interface DateTimePickerProps {
   /**
@@ -232,4 +235,4 @@ interface DateTimePickerProps {
 export default class DateTimePicker extends React.Component<
   DateTimePickerProps,
   any
-> {}
+  > { }


### PR DESCRIPTION
# Overview

The current `ReactNativeModalProps` interface is taking into account the mandatory params used by `react-native-modal` which are `children` and `isVisible`. Since both of them are already handled by your library is safe to exclude them from the extended interface to avoid issues.

# Test Plan

Current error before the change when providing `reactNativeModalPropsIOS`: 
![Screenshot 2019-09-24 at 11 55 11](https://user-images.githubusercontent.com/19332669/65505920-44c08480-dec2-11e9-85e6-cac2e8293f5b.png)

