### PR TITLE
Fixed modal styling

### DIFF
--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -173,7 +173,7 @@ export default class DateTimePickerModal extends React.PureComponent {
     return (
       <Modal
         isVisible={isVisible}
-        style={[pickerStyles.modal, modalStyleIOS]}
+        contentStyle={[pickerStyles.modal, modalStyleIOS]}
         onBackdropPress={this.handleCancel}
         onModalHide={this.handleModalHide}
       >


### PR DESCRIPTION
# Overview

This PR correctly passes default styling and custom styling to the new Modal component, which uses `contentStyle` instead of `style` as property.

# Test Plan

Notice the padding.

Before:
![image](https://user-images.githubusercontent.com/793406/67524447-01b82380-f6b1-11e9-8f44-00b957c32ecc.png)

After:
![image](https://user-images.githubusercontent.com/793406/67524489-15638a00-f6b1-11e9-991f-ec5ab50abf9f.png)
