### PR TITLE
fix: `onHide` callback doesn't work on iOS

### DIFF
--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -108,7 +108,7 @@ export default class DateTimePickerModal extends React.PureComponent {
     this.props.onConfirm(this.state.currentDate);
   };
 
-  handleModalHide = () => {
+  handleHide = () => {
     // Deprecated
     const {
       onModalHide, // Deprecated
@@ -175,7 +175,7 @@ export default class DateTimePickerModal extends React.PureComponent {
         isVisible={isVisible}
         contentStyle={[pickerStyles.modal, modalStyleIOS]}
         onBackdropPress={this.handleCancel}
-        onModalHide={this.handleModalHide}
+        onHide={this.handleHide}
       >
         <View
           style={[


### PR DESCRIPTION
# Overview

`onHideAfterConfirm` callback was recently renamed to `onHide` in [v8.0.0](https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/301). After simple props renaming in my project I found that `onHide` doesn't work anymore.

In `src/DateTimePickerModal.ios.js:178` I found that `onModalHide` Modal prop is used, but there isn't such a props in `src/Modal.js` component actually. Obviously, it was renamed to `onHide`. But this change wasn't propagated to `src/DateTimePickerModal.ios.js`.

This simple PR fixes the issue.