### PR TITLE
Allow to access props interface from outside

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -10,7 +10,7 @@ import { ModalProps } from "react-native-modal";
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 type ReactNativeModalProps = Omit<ModalProps, "children" | "isVisible">;
 
-interface DateTimePickerProps {
+export interface DateTimePickerProps {
   /**
    * The text on the cancel button on iOS
    *


### PR DESCRIPTION


# Overview

This will allow to properly pass typings from custom components

# Test Plan

Tested locally by trying to use DateTimePickerProps in code.
