### PR TITLE
Set the library version to 8.x.x for Expo setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please notice that the `@react-native-community/datetimepicker` package is a nat
 If your project is using [Expo](https://expo.io/), install the library and the community date/time picker using the [Expo CLI](https://docs.expo.io/versions/latest/workflow/expo-cli/):
 
 ```bash
-expo install react-native-modal-datetime-picker @react-native-community/datetimepicker
+expo install react-native-modal-datetime-picker@8.x.x @react-native-community/datetimepicker
 ```
 
 ## Usage


### PR DESCRIPTION
# Overview

It would probably makes things easier for people migrating from version 7. At first I copy and pasted the line without thinking about it and expected it to take care of everything, including bumping the version.
