### PR TITLE
Add testID to DateTimePickerProps

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -202,6 +202,11 @@ export interface DateTimePickerProps {
    * after Confirm was pressed.
    */
   onHide?(date: Date): void;
+  
+  /**
+   * Used to locate this view in end-to-end tests.
+   */
+  testID?: string;
 }
 
 export default class DateTimePicker extends React.Component<


### PR DESCRIPTION
# Overview

testID is already handling by the props spread into the underlying component, this just adds it to type info

# Test Plan

N/A
