### PR TITLE
Support Countdown Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ export default Example;
 | isDarkModeEnabled       | bool      | false         | Is the device using a dark theme?                                                               |
 | isVisible               | bool      | false         | Show the datetime picker?                                                                       |
 | modalStyleIOS           | style     |               | Style of the modal content (iOS)                                                                |
-| mode                    | string    | "date"        | Choose between 'date', 'time', and 'datetime'                                                   |
+| mode                    | string    | "date"        | Choose between 'date', 'time', 'datetime', and 'countdown' (datetime and countdown on iOS only)                                                   |
 | onCancel                | func      | **REQUIRED**  | Function called on dismiss                                                                      |
 | onConfirm               | func      | **REQUIRED**  | Function called on date or time picked. It returns the date or time as a JavaScript Date object |
 | onHide                  | func      | () => null    | Called after the hide animation                                                                 |

--- a/example/App.js
+++ b/example/App.js
@@ -27,7 +27,7 @@ const App = () => {
 
   const durationButton =
     Platform.OS === "ios" ? (
-      <Button title="Show Duration Picker" onPress={showDurationPicker} />
+      <Button title="Show Countdown Picker" onPress={showDurationPicker} />
     ) : (
       <View />
     );
@@ -38,15 +38,11 @@ const App = () => {
       {durationButton}
       <DateTimePickerModal
         isVisible={pickerMode !== null}
+        date={pickerMode === "countdown" ? new Date(1000) : new Date()}
         mode={pickerMode}
+        timeZoneOffsetInMinutes={0}
         onConfirm={handleConfirm}
         onCancel={hidePicker}
-        headerTextIOS={`Pick a ${
-          pickerMode === "countdown"
-            ? "Duration"
-            : pickerMode &&
-              pickerMode.charAt(0).toUpperCase() + pickerMode.slice(1)
-        }`}
       />
     </View>
   );

--- a/example/App.js
+++ b/example/App.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Button, StyleSheet, View } from "react-native";
+import { Button, Platform, StyleSheet, View } from "react-native";
 import DateTimePickerModal from "react-native-modal-datetime-picker";
 
 const App = () => {
@@ -12,6 +12,9 @@ const App = () => {
   const showTimePicker = () => {
     setPickerMode("time");
   };
+  const showDurationPicker = () => {
+    setPickerMode("countdown");
+  };
 
   const hidePicker = () => {
     setPickerMode(null);
@@ -22,15 +25,28 @@ const App = () => {
     hidePicker();
   };
 
+  const durationButton =
+    Platform.OS === "ios" ? (
+      <Button title="Show Duration Picker" onPress={showDurationPicker} />
+    ) : (
+      <View />
+    );
   return (
     <View style={style.root}>
       <Button title="Show Date Picker" onPress={showDatePicker} />
       <Button title="Show Time Picker" onPress={showTimePicker} />
+      {durationButton}
       <DateTimePickerModal
         isVisible={pickerMode !== null}
         mode={pickerMode}
         onConfirm={handleConfirm}
         onCancel={hidePicker}
+        headerTextIOS={`Pick a ${
+          pickerMode === "countdown"
+            ? "Duration"
+            : pickerMode &&
+              pickerMode.charAt(0).toUpperCase() + pickerMode.slice(1)
+        }`}
       />
     </View>
   );

--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -69,7 +69,7 @@ export default class DateTimePickerModal extends React.PureComponent {
     currentDate: this.props.date,
     isPickerVisible: this.props.isVisible,
     isPickerSpinning: false,
-    initialized: false
+    isInitialized: false
   };
 
   didPressConfirm = false;
@@ -92,22 +92,15 @@ export default class DateTimePickerModal extends React.PureComponent {
     });
   }
   componentDidUpdate(prevProps, prevState) {
-    /* console.log(
-     *   `Did Update: Mode: ${this.props.mode}, Visible: ${this.props.isVisible}, prevVisible: ${prevProps.isVisible}`
-     * );*/
     if (
       this.props.mode === "countdown" &&
       this.props.isVisible &&
       !prevProps.isVisible
     ) {
-      setTimeout(() => this.setState({ initialized: true }), 0);
-      /*       console.log("Visible");*/
+      setTimeout(() => this.setState({ isInitialized: true }), 0);
     }
   }
   static getDerivedStateFromProps(props, state) {
-    /* console.log(
-     *   `Derived State:  Mode: ${props.mode}, Visible: ${props.isVisible}, stateVisible: ${state.isPickerVisible}`
-     * );*/
     if (props.isVisible && !state.isPickerVisible) {
       return { currentDate: props.date, isPickerVisible: true };
     }
@@ -135,7 +128,7 @@ export default class DateTimePickerModal extends React.PureComponent {
     } else if (onHide) {
       onHide(this.didPressConfirm, this.state.currentDate);
     }
-    this.setState({ isPickerVisible: false, initialized: false });
+    this.setState({ isPickerVisible: false, isInitialized: false });
   };
 
   handleChange = (event, date) => {
@@ -207,7 +200,7 @@ export default class DateTimePickerModal extends React.PureComponent {
             <PickerComponent
               {...otherProps}
               value={
-                this.props.mode !== "countdown" || this.state.initialized
+                this.props.mode !== "countdown" || this.state.isInitialized
                   ? this.state.currentDate
                   : new Date(this.props.date.getTime() + 1000)
               }

--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -68,12 +68,13 @@ export default class DateTimePickerModal extends React.PureComponent {
   state = {
     currentDate: this.props.date,
     isPickerVisible: this.props.isVisible,
-    isPickerSpinning: false
+    isPickerSpinning: false,
+    initialized: false
   };
 
   didPressConfirm = false;
-
   componentDidMount() {
+    console.log("Did Mount");
     Object.keys(this.props).forEach(prop => {
       // Show a warning if a deprecated prop is being used
       const deprecationInfo = deprecatedPropsInfo.find(x => x.prop === prop);
@@ -91,8 +92,23 @@ export default class DateTimePickerModal extends React.PureComponent {
       }
     });
   }
-
+  componentDidUpdate(prevProps, prevState) {
+    /* console.log(
+     *   `Did Update: Mode: ${this.props.mode}, Visible: ${this.props.isVisible}, prevVisible: ${prevProps.isVisible}`
+     * );*/
+    if (
+      this.props.mode === "countdown" &&
+      this.props.isVisible &&
+      !prevProps.isVisible
+    ) {
+      setTimeout(() => this.setState({ initialized: true }), 0);
+      /*       console.log("Visible");*/
+    }
+  }
   static getDerivedStateFromProps(props, state) {
+    /* console.log(
+     *   `Derived State:  Mode: ${props.mode}, Visible: ${props.isVisible}, stateVisible: ${state.isPickerVisible}`
+     * );*/
     if (props.isVisible && !state.isPickerVisible) {
       return { currentDate: props.date, isPickerVisible: true };
     }
@@ -120,7 +136,7 @@ export default class DateTimePickerModal extends React.PureComponent {
     } else if (onHide) {
       onHide(this.didPressConfirm, this.state.currentDate);
     }
-    this.setState({ isPickerVisible: false });
+    this.setState({ isPickerVisible: false, initialized: false });
   };
 
   handleChange = (event, date) => {
@@ -191,7 +207,11 @@ export default class DateTimePickerModal extends React.PureComponent {
           <View onStartShouldSetResponderCapture={this.handleUserTouchInit}>
             <PickerComponent
               {...otherProps}
-              value={this.state.currentDate}
+              value={
+                this.props.mode !== "countdown" || this.state.initialized
+                  ? this.state.currentDate
+                  : new Date(this.props.date.getTime() + 1000)
+              }
               onChange={this.handleChange}
             />
           </View>

--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -74,7 +74,6 @@ export default class DateTimePickerModal extends React.PureComponent {
 
   didPressConfirm = false;
   componentDidMount() {
-    console.log("Did Mount");
     Object.keys(this.props).forEach(prop => {
       // Show a warning if a deprecated prop is being used
       const deprecationInfo = deprecatedPropsInfo.find(x => x.prop === prop);


### PR DESCRIPTION
# Overview
In Countdown mode, there is a [bug in the underlying library](https://github.com/react-native-community/react-native-datetimepicker/issues/30) that causes the `Confirm` button of this component to not work when a value is first selected by the picker. You have to move the wheel at least twice. This PR implements the workaround suggested in [that issue](https://github.com/react-native-community/react-native-datetimepicker/issues/30).

Although this fixes the problem for the main use case, it unfortunately does not fix it completely. There is a use case (hopefully rare) where, if the user spins the picker to 0 hours, 0 minutes, iOS will immediately advance the picker to 0 hours 1 minute and the `Confirm` button won't work the next time you move the picker.... it has to be moved at least twice. I haven't been able to figure out a workaround for this.

# Test Plan
I modified the example component, adding a `Duration` (countdown) button for iOS only (the underlying component does not support countdown on Android.) I ran the example on an iOS device and it works fine. I also ran on an Android device to make sure I didn't break anything there. 