### PR TITLE
Remove disable confirm

### DIFF
--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -245,11 +245,7 @@ const headerStyles = StyleSheet.create({
   }
 });
 
-export const ConfirmButton = ({
-  isDarkModeEnabled,
-  onPress,
-  label
-}) => {
+export const ConfirmButton = ({ isDarkModeEnabled, onPress, label }) => {
   const underlayColor = isDarkModeEnabled
     ? HIGHLIGHT_COLOR_DARK
     : HIGHLIGHT_COLOR_LIGHT;

--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -69,8 +69,7 @@ export default class DateTimePickerModal extends React.PureComponent {
 
   state = {
     currentDate: this.props.date,
-    isPickerVisible: this.props.isVisible,
-    isPickerSpinning: false
+    isPickerVisible: this.props.isVisible
   };
 
   didPressConfirm = false;
@@ -129,12 +128,7 @@ export default class DateTimePickerModal extends React.PureComponent {
     if (this.props.onChange) {
       this.props.onChange(date);
     }
-    this.setState({ currentDate: date, isPickerSpinning: false });
-  };
-
-  handleUserTouchInit = () => {
-    this.setState({ isPickerSpinning: true });
-    return false;
+    this.setState({ currentDate: date });
   };
 
   render() {
@@ -190,16 +184,13 @@ export default class DateTimePickerModal extends React.PureComponent {
           ]}
         >
           <HeaderComponent label={titleIOS || headerTextIOS} />
-          <View onStartShouldSetResponderCapture={this.handleUserTouchInit}>
-            <PickerComponent
-              {...otherProps}
-              value={this.state.currentDate}
-              onChange={this.handleChange}
-            />
-          </View>
+          <PickerComponent
+            {...otherProps}
+            value={this.state.currentDate}
+            onChange={this.handleChange}
+          />
           <ConfirmButtonComponent
             isDarkModeEnabled={isDarkModeEnabled}
-            isDisabled={this.state.isPickerSpinning}
             onPress={this.handleConfirm}
             label={confirmTextIOS}
           />
@@ -256,7 +247,6 @@ const headerStyles = StyleSheet.create({
 
 export const ConfirmButton = ({
   isDarkModeEnabled,
-  isDisabled,
   onPress,
   label
 }) => {
@@ -268,7 +258,6 @@ export const ConfirmButton = ({
       style={confirmButtonStyles.button}
       underlayColor={underlayColor}
       onPress={onPress}
-      disabled={isDisabled}
     >
       <Text style={confirmButtonStyles.text}>{label}</Text>
     </TouchableHighlight>


### PR DESCRIPTION
Since we can't precisely know when/if the user started spinning the component (on IOS) to pick a date, we can't disable the "Confirm" button without bugs popping up continuously.
This PR removes the logic that disables the "Confirm" button until the component has stopped spinning.
