### PR TITLE
Update Typings to include @react-native-community/datetimepicker props

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,11 +3,14 @@
 // Definitions by:
 // Kyle Roach <https://github.com/iRoachie>
 // Michiel De Mey <https://github.com/MichielDeMey>
-// TypeScript Version: 2.3.2
+// TypeScript Version: 3.5
 
 import * as React from "react";
-import { ViewStyle, TextStyle } from "react-native";
-import { IOSNativeProps } from "@react-native-community/datetimepicker";
+import { ViewStyle } from "react-native";
+import {
+  IOSNativeProps,
+  AndroidNativeProps
+} from "@react-native-community/datetimepicker";
 
 export type CancelButtonComponent = React.ComponentType<{
   isDarkModeEnabled: boolean;
@@ -205,6 +208,8 @@ export interface DateTimePickerProps {
 }
 
 export default class DateTimePicker extends React.Component<
-  DateTimePickerProps,
+  DateTimePickerProps &
+    Omit<IOSNativeProps, "value"> &
+    Omit<AndroidNativeProps, "value">,
   any
 > {}


### PR DESCRIPTION
# Overview

Fixes https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/371

# Test Plan

Install the package on a typescript project and verify that typescript doesn't complain on Props that belong to @react-native-community/datetimepicker

On a side note:
This fix includes the Typescript Omit type to filter out the required `value` parameters of the original props.
If you have a minimum version of Typescript specified somewhere that needs to be bumped to > 3.5
