### PR TITLE
fix: typescript types did not allow mode='datetime'

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -209,7 +209,7 @@ export interface DateTimePickerProps {
 
 export default class DateTimePicker extends React.Component<
   DateTimePickerProps &
-    Omit<IOSNativeProps, "value"> &
-    Omit<AndroidNativeProps, "value">,
+    Omit<IOSNativeProps, "value" | "mode"> &
+    Omit<AndroidNativeProps, "value" | "mode">,
   any
 > {}


### PR DESCRIPTION
Also added @typescript-eslint/parser and typescript as devDependencies.
This was necessary because the pre-commit hook was preventing me from
committing because these packages were missing. 
**I don't have eslint experience so this should be reviewed**

# Overview

PR #374 unintentionally broke the `mode` prop.  `DateTimePickerProps` defines the `mode` prop as `'date' | 'time' | 'datetime' | undefined`, as does `IOSNativeProps` from `@react-native-community/datetimepicker`. However, `AndroidNativeProps` defines `mode` as `'date' | 'time' | undefined`.  As a result, the intersection type `DateTimePickerProps & IOSNativeProps & AndroidNativeProps` expects `mode` to be `'date' | 'time' | undefined`, i.e. `'datetime'` is not allowed.

# Test Plan

1. Download my minimal repro: https://github.com/srmagura/datepicker-type-repro
2. `yarn`  then  `yarn tsc`   (should result in an error)
3. Copy my version of `index.d.ts` into `node_modules/react-native-modal-datetime-picker/typings/index.d.ts`
4. Run `yarn tsc` again and there are no errors.
