### PR TITLE
fix: Use the correct width/height on rotation

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -61,8 +61,8 @@ export class Modal extends Component {
   }
 
   handleDimensionsUpdate = dimensionsUpdate => {
-    const deviceWidth = dimensionsUpdate.width;
-    const deviceHeight = dimensionsUpdate.height;
+    const deviceWidth = dimensionsUpdate.window.width;
+    const deviceHeight = dimensionsUpdate.window.height;
     if (
       deviceWidth !== this.state.deviceWidth ||
       deviceHeight !== this.state.deviceHeight


### PR DESCRIPTION
Fixes #379 
As per [documentation](https://reactnative.dev/docs/dimensions) the dimentions should be obtained from the `window` item.
