### PR TITLE
feat: Added "modalPropsIOS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ export default Example;
 | headerTextIOS           | string    | "Pick a date" | The title text of header (iOS)                                                                  |
 | isDarkModeEnabled       | bool      | false         | Is the device using a dark theme?                                                               |
 | isVisible               | bool      | false         | Show the datetime picker?                                                                       |
+| modalPropsIOS           | object    | {}            | Additional [modal](https://reactnative.dev/docs/modal) props for iOS                            |
 | modalStyleIOS           | style     |               | Style of the modal content (iOS)                                                                |
 | mode                    | string    | "date"        | Choose between 'date', 'time', and 'datetime'                                                   |
 | onCancel                | func      | **REQUIRED**  | Function called on dismiss                                                                      |

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -111,7 +111,7 @@ DEPENDENCIES:
   - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - boost-for-react-native
 
 EXTERNAL SOURCES:

--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -45,6 +45,7 @@ export class DateTimePickerModal extends React.PureComponent {
     customPickerIOS: PropTypes.elementType,
     date: PropTypes.instanceOf(Date),
     headerTextIOS: PropTypes.string,
+    modalPropsIOS: PropTypes.any,
     modalStyleIOS: PropTypes.any,
     isDarkModeEnabled: PropTypes.bool,
     isVisible: PropTypes.bool,
@@ -61,6 +62,7 @@ export class DateTimePickerModal extends React.PureComponent {
     cancelTextIOS: "Cancel",
     confirmTextIOS: "Confirm",
     headerTextIOS: "Pick a date",
+    modalPropsIOS: {},
     date: new Date(),
     isDarkModeEnabled: false,
     isVisible: false,
@@ -146,6 +148,7 @@ export class DateTimePickerModal extends React.PureComponent {
       isDarkModeEnabled,
       isVisible,
       modalStyleIOS,
+      modalPropsIOS,
       pickerContainerStyleIOS,
       onCancel,
       onConfirm,
@@ -175,6 +178,7 @@ export class DateTimePickerModal extends React.PureComponent {
         contentStyle={[pickerStyles.modal, modalStyleIOS]}
         onBackdropPress={this.handleCancel}
         onHide={this.handleHide}
+        {...modalPropsIOS}
       >
         <View
           style={[

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -100,7 +100,12 @@ export class Modal extends Component {
   };
 
   render() {
-    const { children, onBackdropPress, contentStyle } = this.props;
+    const {
+      children,
+      onBackdropPress,
+      contentStyle,
+      ...otherProps
+    } = this.props;
     const { deviceHeight, deviceWidth, isVisible } = this.state;
     const backdropAnimatedStyle = {
       opacity: this.animVal.interpolate({
@@ -120,7 +125,12 @@ export class Modal extends Component {
       ]
     };
     return (
-      <ReactNativeModal transparent animationType="none" visible={isVisible}>
+      <ReactNativeModal
+        transparent
+        animationType="none"
+        visible={isVisible}
+        {...otherProps}
+      >
         <TouchableWithoutFeedback onPress={onBackdropPress}>
           <Animated.View
             style={[

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -122,6 +122,13 @@ export interface DateTimePickerProps {
   mode?: "date" | "time" | "datetime";
 
   /**
+   * Additional modal props for iOS.
+   * 
+   * See https://reactnative.dev/docs/modal for the available props.
+   */
+  modalPropsIOS?: Object;
+
+  /**
    * Toggles the time mode on Android between spinner and clock views
    *
    * Default is 'default' which shows either spinner or clock based on Android version


### PR DESCRIPTION
Added a new prop: `modalPropsIOS`. It can be used to pass additional props to the [modal](https://reactnative.dev/docs/modal) component used by the iOS picker.