### PR TITLE
feat: Avoid crashing on unsopported platforms

### DIFF
--- a/src/DateTimePickerModal.js
+++ b/src/DateTimePickerModal.js
@@ -1,0 +1,9 @@
+import React from "react";
+import { Platform } from "react-native";
+
+export default function DateTimePickerModal() {
+  React.useEffect(() => {
+    console.warn(`DateTimePicker is not supported on: ${Platform.OS}`);
+  }, []);
+  return null;
+}


### PR DESCRIPTION
Added a platform-agnostic entry point (except for Android/iOS) that will show a warning for unsupported platforms (instead of making them crash). 