### PR TITLE
Adds basic accessibility support for iOS modal buttons.

### DIFF
--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -212,6 +212,9 @@ export const ConfirmButton = ({
       style={style.button}
       underlayColor={underlayColor}
       onPress={onPress}
+      accessible={true}
+      accessibilityRole="button"
+      accessibilityLabel={label}
     >
       <Text style={style.text}>{label}</Text>
     </TouchableHighlight>
@@ -252,6 +255,9 @@ export const CancelButton = ({
       style={[style.button, themedButtonStyle]}
       underlayColor={underlayColor}
       onPress={onPress}
+      accessible={true}
+      accessibilityRole="button"
+      accessibilityLabel={label}
     >
       <Text style={style.text}>{label}</Text>
     </TouchableHighlight>


### PR DESCRIPTION
- Added accessibility role "button".
- Added label (same as text so it reads "Cancel button"  for example.

# Overview

I'm using this library and I absolutely love it; for screen readers it's useful to have the role of the accessibility items displayed on the modal: The cancel/confirm buttons being part of those items.

# Test Plan

- Deploy the example app to a real iOS device and turn on VoiceOver, tap on the buttons; It should read: "Cancel Button" instead of just "Cancel" as it is reading right now. You can test this by using the Xcode's accessibility inspector.

I tested on my simulator with the accessibility inspector, which is almost the same.

Video is attached on a zip file since I can't attach .mp4 files on GH
[Video_A11y.zip](https://github.com/mmazzarolo/react-native-modal-datetime-picker/files/4928397/Video_A11y.zip)
