### PR TITLE
(fix)(refactor) Memo'd component to avoid re-rendering upstream which has a bug

### DIFF
--- a/src/DateTimePickerModal.android.js
+++ b/src/DateTimePickerModal.android.js
@@ -1,62 +1,66 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, memo } from "react";
 import PropTypes from "prop-types";
 import DateTimePicker from "@react-native-community/datetimepicker";
 
-const DateTimePickerModal = ({
-    date, 
-    mode,
-    isVisible, 
-    onCancel, 
-    onConfirm,
-    onHide, 
-    ...otherProps
-  }) =>{
-    const [currentDate, setCurrentDate] = useState(date);
-    const [currentMode, setCurrentMode] = useState(mode === "time" ? "time" : "date");
-    
-    useEffect(()=>{
-      if (isVisible && currentMode === null) {
-        setCurrentMode(mode === "time" ? "time" : "date");
-      } else if (!isVisible) {
-        setCurrentMode(null);
-      }
-    }, [isVisible, currentMode]);
+const DateTimePickerModal = memo(({
+      date, 
+      mode,
+      isVisible, 
+      onCancel, 
+      onConfirm,
+      onHide, 
+      ...otherProps
+    }) =>{
+      const [currentDate, setCurrentDate] = useState(date);
+      const [currentMode, setCurrentMode] = useState(null);
 
-    if (!isVisible || !currentMode) return null;
+      useEffect(()=>{
+        if (isVisible && currentMode === null) {
+          setCurrentMode(mode === "time" ? "time" : "date");
+        } else if (!isVisible) {
+          setCurrentMode(null);
+        }
+      }, [isVisible, currentMode]);
 
-    return (
-      <DateTimePicker
-        {...otherProps}
-        mode={currentMode}
-        value={currentDate}
-        onChange={(event, date) => {
-          if (event.type === "dismissed") {
-            onCancel();
-            onHide(false);
-            return;
-          }
-          if (mode === "datetime") {
-            let nextDate = date;
-            if (currentMode === "date") {
-              setCurrentMode("time")
-              setCurrentDate(new Date(date));
+      if (!isVisible || !currentMode) return null;
+
+      return (
+        <DateTimePicker
+          {...otherProps}
+          mode={currentMode}
+          value={currentDate}
+          onChange={(event, date) => {
+            if (event.type === "dismissed") {
+              onCancel();
+              onHide(false);
               return;
-            } else if (currentMode === "time") {
-              const year = currentDate.getFullYear();
-              const month = currentDate.getMonth();
-              const day = currentDate.getDate();
-              const hours = date.getHours();
-              const minutes = date.getMinutes();
-              nextDate = new Date(year, month, day, hours, minutes);
             }
-          } 
-          setCurrentDate(nextDate)      
-          onConfirm(nextDate);
-          onHide(true, nextDate);
-        }}
-      />
-    );
-};
+            if (mode === "datetime") {
+              let nextDate = date;
+              if (currentMode === "date") {
+                setCurrentMode("time")
+                setCurrentDate(new Date(date));
+                return;
+              } else if (currentMode === "time") {
+                const year = currentDate.getFullYear();
+                const month = currentDate.getMonth();
+                const day = currentDate.getDate();
+                const hours = date.getHours();
+                const minutes = date.getMinutes();
+                nextDate = new Date(year, month, day, hours, minutes);
+              }
+            } 
+            setCurrentDate(nextDate)      
+            onConfirm(nextDate);
+            onHide(true, nextDate);
+          }}
+        />
+      );
+  }, 
+  (prevProps, nextProps) =>
+    prevProps.isVisible === nextProps.isVisible
+    && prevProps.date === nextProps.date
+);
 
 DateTimePickerModal.propTypes = {
   date: PropTypes.instanceOf(Date),
@@ -74,4 +78,4 @@ DateTimePickerModal.defaultProps = {
   onHide: () => {},
 };
 
-export { DateTimePickerModal };
+export {DateTimePickerModal};

--- a/src/DateTimePickerModal.android.js
+++ b/src/DateTimePickerModal.android.js
@@ -1,76 +1,82 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import DateTimePicker from "@react-native-community/datetimepicker";
 
-export class DateTimePickerModal extends React.PureComponent {
-  static propTypes = {
-    date: PropTypes.instanceOf(Date),
-    isVisible: PropTypes.bool,
-    onCancel: PropTypes.func.isRequired,
-    onConfirm: PropTypes.func.isRequired,
-    onHide: PropTypes.func,
-    maximumDate: PropTypes.instanceOf(Date),
-    minimumDate: PropTypes.instanceOf(Date),
-  };
+const DateTimePickerModal = ({
+    date, 
+    mode,
+    isVisible, 
+    onCancel, 
+    onConfirm,
+    onHide, 
+    ...otherProps
+  }) =>{
+    const [currentDate, setCurrentDate] = useState(date);
+    const [currentMode, setCurrentMode] = useState(mode === "time" ? "time" : "date");
 
-  static defaultProps = {
-    date: new Date(),
-    isVisible: false,
-    onHide: () => {},
-  };
+    useEffect(()=>{
+      console.log('initial')
+    },[]);
 
-  state = {
-    currentMode: null,
-  };
-
-  currentDate = this.props.date;
-
-  static getDerivedStateFromProps(props, state) {
-    if (props.isVisible && state.currentMode === null) {
-      return { currentMode: props.mode === "time" ? "time" : "date" };
-    } else if (!props.isVisible) {
-      return { currentMode: null };
-    }
-    return null;
-  }
-
-  handleChange = (event, date) => {
-    if (event.type === "dismissed") {
-      this.props.onCancel();
-      this.props.onHide(false);
-      return;
-    }
-    if (this.props.mode === "datetime") {
-      if (this.state.currentMode === "date") {
-        this.currentDate = new Date(date);
-        this.setState({ currentMode: "time" });
-        return;
-      } else if (this.state.currentMode === "time") {
-        const year = this.currentDate.getFullYear();
-        const month = this.currentDate.getMonth();
-        const day = this.currentDate.getDate();
-        const hours = date.getHours();
-        const minutes = date.getMinutes();
-        this.currentDate = new Date(year, month, day, hours, minutes);
+    useEffect(()=>{
+      if (isVisible && currentMode === null) {
+        setCurrentMode(mode === "time" ? "time" : "date");
+      } else if (!isVisible) {
+        setCurrentMode(null);
       }
-    } else {
-      this.currentDate = date;
-    }
-    this.props.onConfirm(this.currentDate);
-    this.props.onHide(true, this.currentDate);
-  };
+    }, [isVisible, currentMode]);
 
-  render() {
-    const { isVisible, date, ...otherProps } = this.props;
-    const { currentMode } = this.state;
     if (!isVisible || !currentMode) return null;
+
+    console.log(currentDate)
     return (
       <DateTimePicker
         {...otherProps}
         mode={currentMode}
-        value={date}
-        onChange={this.handleChange}
+        value={currentDate}
+        onChange={(event, date) => {
+          if (event.type === "dismissed") {
+            onCancel();
+            onHide(false);
+            return;
+          }
+          if (mode === "datetime") {
+            let nextDate = date;
+            if (currentMode === "date") {
+              setCurrentMode("time")
+              setCurrentDate(new Date(date));
+              return;
+            } else if (currentMode === "time") {
+              const year = currentDate.getFullYear();
+              const month = currentDate.getMonth();
+              const day = currentDate.getDate();
+              const hours = date.getHours();
+              const minutes = date.getMinutes();
+              nextDate = new Date(year, month, day, hours, minutes);
+            }
+          } 
+          setCurrentDate(nextDate)      
+          onConfirm(nextDate);
+          onHide(true, nextDate);
+        }}
       />
     );
-  }
-}
+};
+
+DateTimePickerModal.propTypes = {
+  date: PropTypes.instanceOf(Date),
+  isVisible: PropTypes.bool,
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onHide: PropTypes.func,
+  maximumDate: PropTypes.instanceOf(Date),
+  minimumDate: PropTypes.instanceOf(Date),
+};
+
+DateTimePickerModal.defaultProps = {
+  date: new Date(),
+  isVisible: false,
+  onHide: () => {},
+};
+
+export { DateTimePickerModal };

--- a/src/DateTimePickerModal.android.js
+++ b/src/DateTimePickerModal.android.js
@@ -35,8 +35,8 @@ const DateTimePickerModal = memo(({
               onHide(false);
               return;
             }
+            let nextDate = date;
             if (mode === "datetime") {
-              let nextDate = date;
               if (currentMode === "date") {
                 setCurrentMode("time")
                 setCurrentDate(new Date(date));
@@ -50,7 +50,8 @@ const DateTimePickerModal = memo(({
                 nextDate = new Date(year, month, day, hours, minutes);
               }
             } 
-            setCurrentDate(nextDate)      
+            
+            setCurrentDate(nextDate);
             onConfirm(nextDate);
             onHide(true, nextDate);
           }}

--- a/src/DateTimePickerModal.android.js
+++ b/src/DateTimePickerModal.android.js
@@ -13,11 +13,7 @@ const DateTimePickerModal = ({
   }) =>{
     const [currentDate, setCurrentDate] = useState(date);
     const [currentMode, setCurrentMode] = useState(mode === "time" ? "time" : "date");
-
-    useEffect(()=>{
-      console.log('initial')
-    },[]);
-
+    
     useEffect(()=>{
       if (isVisible && currentMode === null) {
         setCurrentMode(mode === "time" ? "time" : "date");

--- a/src/DateTimePickerModal.android.js
+++ b/src/DateTimePickerModal.android.js
@@ -28,7 +28,7 @@ const DateTimePickerModal = memo(({
         <DateTimePicker
           {...otherProps}
           mode={currentMode}
-          value={currentDate}
+          value={date}
           onChange={(event, date) => {
             if (event.type === "dismissed") {
               onCancel();
@@ -50,8 +50,6 @@ const DateTimePickerModal = memo(({
                 nextDate = new Date(year, month, day, hours, minutes);
               }
             } 
-            
-            setCurrentDate(nextDate);
             onConfirm(nextDate);
             onHide(true, nextDate);
           }}

--- a/src/DateTimePickerModal.android.js
+++ b/src/DateTimePickerModal.android.js
@@ -24,7 +24,6 @@ const DateTimePickerModal = ({
 
     if (!isVisible || !currentMode) return null;
 
-    console.log(currentDate)
     return (
       <DateTimePicker
         {...otherProps}


### PR DESCRIPTION
# Overview

fixes #451, This PR memos the component to avoid triggering a re-render of the upstream library @react-native-community/datetimepicker which recreates the date picker on each render call. I have also converted to hooks while working out how to resolve this issue. 