### PR TITLE
Use dark mode internally rather than passing it in

### DIFF
--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { StyleSheet, Text, TouchableHighlight, View } from "react-native";
+import { StyleSheet, Text, TouchableHighlight, View, Appearance } from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
 import Modal from "./Modal";
 import { isIphoneX } from "./utils";
@@ -29,7 +29,6 @@ export class DateTimePickerModal extends React.PureComponent {
     headerTextIOS: PropTypes.string,
     modalPropsIOS: PropTypes.any,
     modalStyleIOS: PropTypes.any,
-    isDarkModeEnabled: PropTypes.bool,
     isVisible: PropTypes.bool,
     pickerContainerStyleIOS: PropTypes.any,
     onCancel: PropTypes.func.isRequired,
@@ -46,7 +45,6 @@ export class DateTimePickerModal extends React.PureComponent {
     headerTextIOS: "Pick a date",
     modalPropsIOS: {},
     date: new Date(),
-    isDarkModeEnabled: false,
     isVisible: false,
     pickerContainerStyleIOS: {},
   };
@@ -100,7 +98,6 @@ export class DateTimePickerModal extends React.PureComponent {
       customPickerIOS,
       date,
       headerTextIOS,
-      isDarkModeEnabled,
       isVisible,
       modalStyleIOS,
       modalPropsIOS,
@@ -111,6 +108,7 @@ export class DateTimePickerModal extends React.PureComponent {
       onHide,
       ...otherProps
     } = this.props;
+    const isDarkModeEnabled = Appearance.getColorScheme() === 'dark';
 
     const ConfirmButtonComponent = customConfirmButtonIOS || ConfirmButton;
     const CancelButtonComponent = customCancelButtonIOS || CancelButton;


### PR DESCRIPTION
# Overview

This removes the manual dark mode toggle in favour of `Appearance.getColorScheme()`. Fixes #458

# Test Plan

Add the component,
 - Render with light mode (make sure text in spinner is visible)
![image](https://user-images.githubusercontent.com/1284608/89518498-15dba480-d82f-11ea-99c3-8a9877a82e40.png)
 - Switch to dark mode (on sim this is settings -> dev -> dark appearance.
 - Render again and make sure you can still see the text.
![image](https://user-images.githubusercontent.com/1284608/89518548-2b50ce80-d82f-11ea-81ab-f95270c7748c.png)
