### PR TITLE
Update index.d.ts

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -204,8 +204,8 @@ export interface DateTimePickerProps {
 }
 
 export type ReactNativeModalDateTimePickerProps = DateTimePickerProps &
-  Omit<IOSNativeProps, "value" | "mode"> &
-  Omit<AndroidNativeProps, "value" | "mode">;
+  (Omit<IOSNativeProps, "value" | "mode"> |
+  Omit<AndroidNativeProps, "value" | "mode">);
 
 export default class DateTimePicker extends React.Component<
   ReactNativeModalDateTimePickerProps,


### PR DESCRIPTION
I believe the type here should be OR'd to allow for use of props specific to each platform, e.g. `display={'inline'}` on iOS.

# Overview

iOS 14 has added new features to the DateTimePicker supported by the community module but resulting in type errors in the modal solution.