### PR TITLE
update isIphoneX helper

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,15 @@ export const isIphoneX = () => {
     Platform.OS === "ios" &&
     !Platform.isPad &&
     !Platform.isTVOS &&
-    (height === 812 || width === 812 || height === 896 || width === 896)
+    (height === 780 ||
+      width === 780 ||
+      height === 812 ||
+      width === 812 ||
+      height === 844 ||
+      width === 844 ||
+      height === 896 ||
+      width === 896 ||
+      height === 926 ||
+      width === 926)
   );
 };


### PR DESCRIPTION
# Overview

Update `isIphoneX` helper according to `react-native-iphone-x-helper`.

Adds iPhone 12 and iPhone 12 mini compatibility.

https://github.com/ptelad/react-native-iphone-x-helper/blob/master/index.js#L3-L13

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
