### PR TITLE
Using same properties for the translation in Android and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ export default Example;
 
 | Name                    | Type      | Default       | Description                                                                                     |
 | ----------------------- | --------- | ------------- | ----------------------------------------------------------------------------------------------- |
-| cancelTextIOS           | string    | 'Cancel'      | The label of the cancel button (iOS)                                                            |
-| confirmTextIOS          | string    | 'Confirm'     | The label of the confirm button (iOS)                                                           |
+| cancelText              | string    | 'Cancel'      | The label of the cancel button (iOS)                                                            |
+| confirmText             | string    | 'Confirm'     | The label of the confirm button (iOS)                                                           |
 | customCancelButtonIOS   | component |               | Overrides the default cancel button component (iOS)                                             |
 | customConfirmButtonIOS  | component |               | Overrides the default confirm button component (iOS)                                            |
 | customHeaderIOS         | component |               | Overrides the default header component (iOS)                                                    |

--- a/src/DateTimePickerModal.android.js
+++ b/src/DateTimePickerModal.android.js
@@ -11,7 +11,7 @@ const areEqual = (prevProps, nextProps) => {
 };
 
 const DateTimePickerModal = memo(
-  ({ date, mode, isVisible, onCancel, onConfirm, onHide, ...otherProps }) => {
+  ({ date, mode, isVisible, onCancel, onConfirm, onHide, ...otherProps, positiveButtonLabel, negativeButtonLabel }) => {
     const currentDateRef = useRef(date);
     const [currentMode, setCurrentMode] = useState(null);
 
@@ -56,6 +56,8 @@ const DateTimePickerModal = memo(
         mode={currentMode}
         value={date}
         onChange={handleChange}
+        positiveButtonLabel={positiveButtonLabel}
+        negativeButtonLabel={negativeButtonLabel}
       />
     );
   },
@@ -70,12 +72,17 @@ DateTimePickerModal.propTypes = {
   onHide: PropTypes.func,
   maximumDate: PropTypes.instanceOf(Date),
   minimumDate: PropTypes.instanceOf(Date),
+  onHide: PropTypes.func,
+  positiveButtonLabel: PropTypes.string,
+  negativeButtonLabel: PropTypes.string,
 };
 
 DateTimePickerModal.defaultProps = {
   date: new Date(),
   isVisible: false,
   onHide: () => {},
+  positiveButtonLabel: 'Confirm',
+  negativeButtonLabel: 'Cancel',
 };
 
 export { DateTimePickerModal };

--- a/src/DateTimePickerModal.android.js
+++ b/src/DateTimePickerModal.android.js
@@ -11,7 +11,7 @@ const areEqual = (prevProps, nextProps) => {
 };
 
 const DateTimePickerModal = memo(
-  ({ date, mode, isVisible, onCancel, onConfirm, onHide, ...otherProps, positiveButtonLabel, negativeButtonLabel }) => {
+  ({ date, mode, isVisible, onCancel, onConfirm, onHide, positiveButtonLabel, negativeButtonLabel, ...otherProps }) => {
     const currentDateRef = useRef(date);
     const [currentMode, setCurrentMode] = useState(null);
 

--- a/src/DateTimePickerModal.android.js
+++ b/src/DateTimePickerModal.android.js
@@ -11,7 +11,7 @@ const areEqual = (prevProps, nextProps) => {
 };
 
 const DateTimePickerModal = memo(
-  ({ date, mode, isVisible, onCancel, onConfirm, onHide, positiveButtonLabel, negativeButtonLabel, ...otherProps }) => {
+  ({ date, mode, isVisible, onCancel, onConfirm, onHide, confirmText, cancelText, ...otherProps }) => {
     const currentDateRef = useRef(date);
     const [currentMode, setCurrentMode] = useState(null);
 
@@ -56,8 +56,8 @@ const DateTimePickerModal = memo(
         mode={currentMode}
         value={date}
         onChange={handleChange}
-        positiveButtonLabel={positiveButtonLabel}
-        negativeButtonLabel={negativeButtonLabel}
+        positiveButtonLabel={confirmText}
+        negativeButtonLabel={cancelText}
       />
     );
   },

--- a/src/DateTimePickerModal.android.js
+++ b/src/DateTimePickerModal.android.js
@@ -56,8 +56,8 @@ const DateTimePickerModal = memo(
         mode={currentMode}
         value={date}
         onChange={handleChange}
-        positiveButtonLabel={confirmText}
-        negativeButtonLabel={cancelText}
+        confirmTextAndroid={confirmText}
+        cancelTextAndroid={cancelText}
       />
     );
   },
@@ -73,16 +73,16 @@ DateTimePickerModal.propTypes = {
   maximumDate: PropTypes.instanceOf(Date),
   minimumDate: PropTypes.instanceOf(Date),
   onHide: PropTypes.func,
-  positiveButtonLabel: PropTypes.string,
-  negativeButtonLabel: PropTypes.string,
+  confirmTextAndroid: PropTypes.string,
+  cancelTextAndroid: PropTypes.string,
 };
 
 DateTimePickerModal.defaultProps = {
   date: new Date(),
   isVisible: false,
   onHide: () => {},
-  positiveButtonLabel: 'Confirm',
-  negativeButtonLabel: 'Cancel',
+  confirmTextAndroid: 'Confirm',
+  cancelTextAndroid: 'Cancel',
 };
 
 export { DateTimePickerModal };

--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -25,8 +25,8 @@ export const TITLE_COLOR = "#8f8f8f";
 
 export class DateTimePickerModal extends React.PureComponent {
   static propTypes = {
-    cancelTextIOS: PropTypes.string,
-    confirmTextIOS: PropTypes.string,
+    cancelText: PropTypes.string,
+    confirmText: PropTypes.string,
     customCancelButtonIOS: PropTypes.elementType,
     customConfirmButtonIOS: PropTypes.elementType,
     customHeaderIOS: PropTypes.elementType,
@@ -47,8 +47,8 @@ export class DateTimePickerModal extends React.PureComponent {
   };
 
   static defaultProps = {
-    cancelTextIOS: "Cancel",
-    confirmTextIOS: "Confirm",
+    cancelText: "Cancel",
+    confirmText: "Confirm",
     headerTextIOS: "Pick a date",
     modalPropsIOS: {},
     date: new Date(),
@@ -98,8 +98,8 @@ export class DateTimePickerModal extends React.PureComponent {
 
   render() {
     const {
-      cancelTextIOS,
-      confirmTextIOS,
+      cancelText,
+      confirmText,
       customCancelButtonIOS,
       customConfirmButtonIOS,
       customHeaderIOS,
@@ -159,13 +159,13 @@ export class DateTimePickerModal extends React.PureComponent {
           <ConfirmButtonComponent
             isDarkModeEnabled={_isDarkModeEnabled}
             onPress={this.handleConfirm}
-            label={confirmTextIOS}
+            label={confirmText}
           />
         </View>
         <CancelButtonComponent
           isDarkModeEnabled={_isDarkModeEnabled}
           onPress={this.handleCancel}
-          label={cancelTextIOS}
+          label={cancelText}
         />
       </Modal>
     );

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -46,6 +46,20 @@ export interface DateTimePickerProps {
   confirmTextIOS?: string;
 
   /**
+   * The text on the cancel button on Android
+   *
+   * Default is 'Cancel'
+   */
+  positiveButtonLabel?: string;
+
+  /**
+   * The text on the confirm button on Android
+   *
+   * Default is 'Confirm'
+   */
+  negativeButtonLabel?: string;
+
+  /**
    * A custom component for the cancel button on iOS
    */
   customCancelButtonIOS?: CancelButtonComponent;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -32,32 +32,18 @@ export type PickerComponent = React.ComponentType<IOSNativeProps>;
 
 export interface DateTimePickerProps {
   /**
-   * The text on the cancel button on iOS
+   * The text on the cancel button on iOS & Android
    *
    * Default is 'Cancel'
    */
-  cancelTextIOS?: string;
+  cancelText?: string;
 
   /**
-   * The text on the confirm button on iOS
+   * The text on the confirm button on iOS & Android
    *
    * Default is 'Confirm'
    */
-  confirmTextIOS?: string;
-
-  /**
-   * The text on the cancel button on Android
-   *
-   * Default is 'Cancel'
-   */
-  positiveButtonLabel?: string;
-
-  /**
-   * The text on the confirm button on Android
-   *
-   * Default is 'Confirm'
-   */
-  negativeButtonLabel?: string;
+  confirmText?: string;
 
   /**
    * A custom component for the cancel button on iOS


### PR DESCRIPTION
# Overview

I added some changes in **react-native-community/datetimepicker** to have translations in Android.

# Test Plan

By testing these changes on an Android device, I saw that these changes work.
