### PR TITLE
Memoized equal check should check a date's milliseconds

### DIFF
--- a/src/DateTimePickerModal.android.js
+++ b/src/DateTimePickerModal.android.js
@@ -6,7 +6,7 @@ import DateTimePicker from "@react-native-community/datetimepicker";
 const areEqual = (prevProps, nextProps) => {
   return (
     prevProps.isVisible === nextProps.isVisible &&
-    prevProps.date === nextProps.date
+    prevProps.date.getTime() === nextProps.date.getTime()
   );
 };
 


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Comparing two dates is not possible using the `===` operator. When you would like to check the equality of two dates, you need to use the `getTime()` method. Our component was still re-rendering before comparing dates with `getTime()`.

Object equality isn't tested by the internal value of the object, but by identity. In other words, if it isn't the exact same copy of the Date object, it isn't considered equal.

Here we compare the return values of getTime. The getTime method returns an integer representing the number of milliseconds since midnight of January 1, 1970 (the beginning of the Unix epoch).