### PR TITLE
Added dark theme option to confirm button

### DIFF
--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -14,6 +14,7 @@ import { isIphoneX } from "./utils";
 export const BACKGROUND_COLOR_LIGHT = "white";
 export const BACKGROUND_COLOR_DARK = "#0E0E0E";
 export const BORDER_COLOR = "#d5d5d5";
+export const BORDER_COLOR_DARK = "#272729";
 export const BORDER_RADIUS = 13;
 export const BUTTON_FONT_WEIGHT = "normal";
 export const BUTTON_FONT_COLOR = "#007ff9";
@@ -218,12 +219,16 @@ export const ConfirmButton = ({
   label,
   style = confirmButtonStyles,
 }) => {
+  const themedButtonStyle = isDarkModeEnabled
+    ? confirmButtonStyles.buttonDark
+    : confirmButtonStyles.buttonLight;
+
   const underlayColor = isDarkModeEnabled
     ? HIGHLIGHT_COLOR_DARK
     : HIGHLIGHT_COLOR_LIGHT;
   return (
     <TouchableHighlight
-      style={style.button}
+      style={[themedButtonStyle, style.button]}
       underlayColor={underlayColor}
       onPress={onPress}
       accessible={true}
@@ -237,11 +242,16 @@ export const ConfirmButton = ({
 
 export const confirmButtonStyles = StyleSheet.create({
   button: {
-    borderColor: BORDER_COLOR,
     borderTopWidth: StyleSheet.hairlineWidth,
     backgroundColor: "transparent",
     height: 57,
     justifyContent: "center",
+  },
+  buttonLight: {
+    borderColor: BORDER_COLOR,
+  },
+  buttonDark: {
+    borderColor: BORDER_COLOR_DARK,
   },
   text: {
     textAlign: "center",


### PR DESCRIPTION
When dark mode is on, the `ConfirmButton` top border remains with a light color.
<img width="395" alt="Screen Shot 2021-04-18 at 16 57 57" src="https://user-images.githubusercontent.com/13344923/115148357-d3c65c00-a067-11eb-9850-888f08afe8b5.png">

The PR changes it to have a darker color:
<img width="372" alt="Screen Shot 2021-04-18 at 16 58 14" src="https://user-images.githubusercontent.com/13344923/115148407-1851f780-a068-11eb-8942-eca897d0ab0d.png">

(it seems transparent in the picture - however on device it looks great 🌚)