### PR TITLE
Add backdrop color ios backdrop opacity ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ export default Example;
 | onConfirm               | func      | **REQUIRED**  | Function called on date or time picked. It returns the date or time as a JavaScript Date object |
 | onHide                  | func      | () => null    | Called after the hide animation                                                                 |
 | pickerContainerStyleIOS | style     |               | The style of the picker container (iOS)                                                         |
+| backdropColorIOS | string     | "black"              | The color of the modal backdropColor (iOS)                                                         |
+| backdropOpacityIOS | number     | 0.4              | The opacity of the modal backdrop (iOS)                                                           |
 
 👉 Please notice that **all the [`@react-native-community/react-native-datetimepicker`](https://github.com/react-native-community/react-native-datetimepicker) props are also supported**!
 

--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -116,6 +116,8 @@ export class DateTimePickerModal extends React.PureComponent {
       onConfirm,
       onChange,
       onHide,
+      backdropColorIOS,
+      backdropOpacityIOS,
       ...otherProps
     } = this.props;
     const isAppearanceModuleAvailable = !!(
@@ -141,6 +143,8 @@ export class DateTimePickerModal extends React.PureComponent {
         contentStyle={[pickerStyles.modal, modalStyleIOS]}
         onBackdropPress={this.handleCancel}
         onHide={this.handleHide}
+        backdropColorIOS={backdropColorIOS}
+        backdropOpacityIOS={backdropOpacityIOS}
         {...modalPropsIOS}
       >
         <View

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -11,6 +11,7 @@ import {
 } from "react-native";
 
 const MODAL_ANIM_DURATION = 300;
+const MODAL_BACKDROP_COLOR = "black";
 const MODAL_BACKDROP_OPACITY = 0.4;
 
 export class Modal extends Component {
@@ -19,6 +20,8 @@ export class Modal extends Component {
     onHide: PropTypes.func,
     isVisible: PropTypes.bool,
     contentStyle: PropTypes.any,
+    backdropColorIOS: PropTypes.string,
+    backdropOpacityIOS: PropTypes.number,
   };
 
   static defaultProps = {
@@ -104,13 +107,16 @@ export class Modal extends Component {
       children,
       onBackdropPress,
       contentStyle,
+      backdropColorIOS = MODAL_BACKDROP_COLOR,
+      backdropOpacityIOS = MODAL_BACKDROP_OPACITY,
       ...otherProps
     } = this.props;
+
     const { deviceHeight, deviceWidth, isVisible } = this.state;
     const backdropAnimatedStyle = {
       opacity: this.animVal.interpolate({
         inputRange: [0, 1],
-        outputRange: [0, MODAL_BACKDROP_OPACITY],
+        outputRange: [0, backdropOpacityIOS],
       }),
     };
     const contentAnimatedStyle = {
@@ -136,7 +142,11 @@ export class Modal extends Component {
             style={[
               styles.backdrop,
               backdropAnimatedStyle,
-              { width: deviceWidth, height: deviceHeight },
+              {
+                backgroundColor: backdropColorIOS,
+                width: deviceWidth,
+                height: deviceHeight,
+              },
             ]}
           />
         </TouchableWithoutFeedback>
@@ -167,7 +177,6 @@ const styles = StyleSheet.create({
     bottom: 0,
     left: 0,
     right: 0,
-    backgroundColor: "black",
     opacity: 0,
   },
   content: {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -32,6 +32,20 @@ export type PickerComponent = React.ComponentType<IOSNativeProps>;
 
 export interface DateTimePickerProps {
   /**
+   * The modal backdrop color on iOS
+   *
+   * Default is 'black'
+   */
+  backdropColorIOS?: string;
+
+  /**
+   * The modal backdrop opacity on iOS
+   *
+   * Default is '0.4'
+   */
+  backdropOpacityIOS?: number;
+
+  /**
    * The text on the cancel button on iOS
    *
    * Default is 'Cancel'


### PR DESCRIPTION
# Overview

I wanted to change the iOS backdrop color & backdrop opacity just like I'm used to in `react-native-modal` I think this can be a useful feature to give users more flexibility.

## What has been done
- Added `backdropColorIOS` prop to `types.d.s`, `modal.js` and `modal.ios.js`
- Added `backdropOpacityIOS ` prop to `types.d.s`, `modal.js` and `modal.ios.js` 
- Added `MODAL_BACKDROP_COLOR` default 'black'
- Updated documentation

# Test Plan

Add the props to the component and see the magic!
```
backdropColorIOS="yellow"
backdropOpacityIOS={0.9}
```
<img width="568" alt="Screenshot 2021-04-23 at 18 35 34" src="https://user-images.githubusercontent.com/33637221/115902499-c859a300-a462-11eb-953b-1228482550dd.png">

```
backdropColorIOS="pink"
backdropOpacityIOS={0.9}
```
<img width="568" alt="Screenshot 2021-04-23 at 18 35 52" src="https://user-images.githubusercontent.com/33637221/115902549-d3acce80-a462-11eb-8603-2f0e34fa7a1b.png">

```
backdropColorIOS="blue"
backdropOpacityIOS={0.2}
```
<img width="568" alt="Screenshot 2021-04-23 at 18 36 03" src="https://user-images.githubusercontent.com/33637221/115902577-d9a2af80-a462-11eb-9ff4-8a8a3746737c.png">


