### PR TITLE
fix: Change default header text for time on iOS

### DIFF
--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -50,7 +50,6 @@ export class DateTimePickerModal extends React.PureComponent {
   static defaultProps = {
     cancelTextIOS: "Cancel",
     confirmTextIOS: "Confirm",
-    headerTextIOS: "Pick a date",
     modalPropsIOS: {},
     date: new Date(),
     isDarkModeEnabled: undefined,
@@ -135,6 +134,11 @@ export class DateTimePickerModal extends React.PureComponent {
       ? pickerStyles.containerDark
       : pickerStyles.containerLight;
 
+    const headerText =
+      headerTextIOS || this.props.mode === "time"
+        ? "Pick a time"
+        : "Pick a date";
+
     return (
       <Modal
         isVisible={isVisible}
@@ -150,7 +154,7 @@ export class DateTimePickerModal extends React.PureComponent {
             pickerContainerStyleIOS,
           ]}
         >
-          <HeaderComponent label={headerTextIOS} />
+          <HeaderComponent label={headerText} />
           <PickerComponent
             display="spinner"
             {...otherProps}


### PR DESCRIPTION
Changed "Pick a date" to be "Pick a time" when mode is set to time (and no manual value is specified).

![image](https://user-images.githubusercontent.com/64864175/117089564-dbeaf080-ad23-11eb-9a86-0d7119ca4a2f.png)
