### PR TITLE
Fix: header text bug on iOS

### DIFF
--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -135,9 +135,9 @@ export class DateTimePickerModal extends React.PureComponent {
       : pickerStyles.containerLight;
 
     const headerText =
-      headerTextIOS || this.props.mode === "time"
+      headerTextIOS || (this.props.mode === "time"
         ? "Pick a time"
-        : "Pick a date";
+        : "Pick a date");
 
     return (
       <Modal


### PR DESCRIPTION
The header text is always "Pick a time" on iOS after #560 merged.