### PR TITLE
removeListener deprecated in favor of remove()

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "semantic-release": "^17.1.2"
   },
   "peerDependencies": {
-    "@react-native-community/datetimepicker": ">=3.0.0"
+    "@react-native-community/datetimepicker": ">=3.0.0",
+    "react-native": ">=0.65.0"
   },
   "husky": {
     "hooks": {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -36,22 +36,21 @@ export class Modal extends Component {
   animVal = new Animated.Value(0);
   _isMounted = false;
 
+  static _deviceEventEmitter = null;
+
   componentDidMount() {
     this._isMounted = true;
     if (this.state.isVisible) {
       this.show();
     }
-    DeviceEventEmitter.addListener(
+    this._deviceEventEmitter = DeviceEventEmitter.addListener(
       "didUpdateDimensions",
       this.handleDimensionsUpdate
     );
   }
 
   componentWillUnmount() {
-    DeviceEventEmitter.removeListener(
-      "didUpdateDimensions",
-      this.handleDimensionsUpdate
-    );
+    this._deviceEventEmitter.remove();
     this._isMounted = false;
   }
 


### PR DESCRIPTION
# Overview

With ReactNative 0.65.0 the removeListener was deprecated in favor of `remove()`

https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#deprecated
