### PR TITLE
refactor(ios): remove deprecated header visibility & logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,30 +91,28 @@ export default Example;
 
 👉 Please notice that **all the [`@react-native-community/react-native-datetimepicker`](https://github.com/react-native-community/react-native-datetimepicker) props are supported** as well!
 
-| Name                      | Type      | Default       | Description                                                                                         |
-| ------------------------- | --------- | ------------- | --------------------------------------------------------------------------------------------------- |
-| `cancelButtonTestID`      | string    |               | Used to locate cancel button in end-to-end tests                                                    |
-| `confirmButtonTestID`     | string    |               | Used to locate confirm button in end-to-end tests                                                   |
-| `cancelTextIOS`           | string    | "Cancel"      | The label of the cancel button (iOS)                                                                |
-| `confirmTextIOS`          | string    | "Confirm"     | The label of the confirm button (iOS)                                                               |
-| `customCancelButtonIOS`   | component |               | Overrides the default cancel button component (iOS)                                                 |
-| `customConfirmButtonIOS`  | component |               | Overrides the default confirm button component (iOS)                                                |
-| `customHeaderIOS`         | component |               | Overrides the default header component (iOS)                                                        |
-| `customPickerIOS`         | component |               | Overrides the default native picker component (iOS)                                                 |
-| `date`                    | obj       | new Date()    | Initial selected date/time                                                                          |
-| `headerTextIOS`           | string    | "Pick a date" | The title text of header (iOS)                                                                      |
-| `isVisible`               | bool      | false         | Show the datetime picker?                                                                           |
-| `isDarkModeEnabled`       | bool?     | undefined     | Forces the picker dark/light mode if set (otherwise fallbacks to the Appearance color scheme) (iOS) |
-| `isHeaderVisibleIOS`      | bool?     | false         | Show the built-in header on iOS (deprecated — use `customHeaderIOS` instead)                        |
-| `modalPropsIOS`           | object    | {}            | Additional [modal](https://reactnative.dev/docs/modal) props for iOS                                |
-| `modalStyleIOS`           | style     |               | Style of the modal content (iOS)                                                                    |
-| `mode`                    | string    | "date"        | Choose between "date", "time", and "datetime"                                                       |
-| `onCancel`                | func      | **REQUIRED**  | Function called on dismiss                                                                          |
-| `onConfirm`               | func      | **REQUIRED**  | Function called on date or time picked. It returns the date or time as a JavaScript Date object     |
-| `onHide`                  | func      | () => null    | Called after the hide animation                                                                     |
-| `pickerContainerStyleIOS` | style     |               | The style of the picker container (iOS)                                                             |
-| `pickerStyleIOS`          | style     |               | The style of the picker component wrapper (iOS)                                                     |
-| `backdropStyleIOS`        | style     |               | The style of the picker backdrop view style (iOS)                                                   |
+| Name                      | Type      | Default      | Description                                                                                         |
+| ------------------------- | --------- | ------------ | --------------------------------------------------------------------------------------------------- |
+| `cancelButtonTestID`      | string    |              | Used to locate cancel button in end-to-end tests                                                    |
+| `confirmButtonTestID`     | string    |              | Used to locate confirm button in end-to-end tests                                                   |
+| `cancelTextIOS`           | string    | "Cancel"     | The label of the cancel button (iOS)                                                                |
+| `confirmTextIOS`          | string    | "Confirm"    | The label of the confirm button (iOS)                                                               |
+| `customCancelButtonIOS`   | component |              | Overrides the default cancel button component (iOS)                                                 |
+| `customConfirmButtonIOS`  | component |              | Overrides the default confirm button component (iOS)                                                |
+| `customHeaderIOS`         | component |              | Overrides the default header component (iOS)                                                        |
+| `customPickerIOS`         | component |              | Overrides the default native picker component (iOS)                                                 |
+| `date`                    | obj       | new Date()   | Initial selected date/time                                                                          |
+| `isVisible`               | bool      | false        | Show the datetime picker?                                                                           |
+| `isDarkModeEnabled`       | bool?     | undefined    | Forces the picker dark/light mode if set (otherwise fallbacks to the Appearance color scheme) (iOS) |
+| `modalPropsIOS`           | object    | {}           | Additional [modal](https://reactnative.dev/docs/modal) props for iOS                                |
+| `modalStyleIOS`           | style     |              | Style of the modal content (iOS)                                                                    |
+| `mode`                    | string    | "date"       | Choose between "date", "time", and "datetime"                                                       |
+| `onCancel`                | func      | **REQUIRED** | Function called on dismiss                                                                          |
+| `onConfirm`               | func      | **REQUIRED** | Function called on date or time picked. It returns the date or time as a JavaScript Date object     |
+| `onHide`                  | func      | () => null   | Called after the hide animation                                                                     |
+| `pickerContainerStyleIOS` | style     |              | The style of the picker container (iOS)                                                             |
+| `pickerStyleIOS`          | style     |              | The style of the picker component wrapper (iOS)                                                     |
+| `backdropStyleIOS`        | style     |              | The style of the picker backdrop view style (iOS)                                                   |
 
 ## Frequently Asked Questions
 

--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -21,8 +21,6 @@ export const BUTTON_FONT_COLOR = "#007ff9";
 export const BUTTON_FONT_SIZE = 20;
 export const HIGHLIGHT_COLOR_DARK = "#444444";
 export const HIGHLIGHT_COLOR_LIGHT = "#ebebeb";
-export const TITLE_FONT_SIZE = 20;
-export const TITLE_COLOR = "#8f8f8f";
 
 export class DateTimePickerModal extends React.PureComponent {
   static propTypes = {
@@ -35,11 +33,9 @@ export class DateTimePickerModal extends React.PureComponent {
     customHeaderIOS: PropTypes.elementType,
     customPickerIOS: PropTypes.elementType,
     date: PropTypes.instanceOf(Date),
-    headerTextIOS: PropTypes.string,
     modalPropsIOS: PropTypes.any,
     modalStyleIOS: PropTypes.any,
     isDarkModeEnabled: PropTypes.bool,
-    isHeaderVisibleIOS: PropTypes.bool,
     isVisible: PropTypes.bool,
     pickerContainerStyleIOS: PropTypes.any,
     pickerStyleIOS: PropTypes.any,
@@ -58,7 +54,6 @@ export class DateTimePickerModal extends React.PureComponent {
     modalPropsIOS: {},
     date: new Date(),
     isDarkModeEnabled: undefined,
-    isHeaderVisibleIOS: false,
     isVisible: false,
     pickerContainerStyleIOS: {},
     pickerStyleIOS: {},
@@ -77,14 +72,6 @@ export class DateTimePickerModal extends React.PureComponent {
       return { currentDate: props.date, isPickerVisible: true };
     }
     return null;
-  }
-
-  componentDidMount() {
-    if (this.props.isHeaderVisibleIOS) {
-      console.warn(
-        `Please notice that the built-in iOS header will not be supported anymore in the future. If you're still planning to show a header, it's recommended to provide your own header implementation using "customHeaderIOS" (which will continue to be supported).`
-      );
-    }
   }
 
   handleCancel = () => {
@@ -124,9 +111,7 @@ export class DateTimePickerModal extends React.PureComponent {
       customPickerIOS,
       date,
       display,
-      headerTextIOS,
       isDarkModeEnabled,
-      isHeaderVisibleIOS,
       isVisible,
       modalStyleIOS,
       modalPropsIOS,
@@ -149,16 +134,12 @@ export class DateTimePickerModal extends React.PureComponent {
 
     const ConfirmButtonComponent = customConfirmButtonIOS || ConfirmButton;
     const CancelButtonComponent = customCancelButtonIOS || CancelButton;
-    const HeaderComponent = customHeaderIOS || Header;
     const PickerComponent = customPickerIOS || DateTimePicker;
+    const HeaderComponent = customHeaderIOS;
 
     const themedContainerStyle = _isDarkModeEnabled
       ? pickerStyles.containerDark
       : pickerStyles.containerLight;
-
-    const headerText =
-      headerTextIOS ||
-      (this.props.mode === "time" ? "Pick a time" : "Pick a date");
 
     return (
       <Modal
@@ -176,8 +157,8 @@ export class DateTimePickerModal extends React.PureComponent {
             pickerContainerStyleIOS,
           ]}
         >
-          {isHeaderVisibleIOS && <HeaderComponent label={headerText} />}
-          {!isHeaderVisibleIOS && display === "inline" && (
+          {HeaderComponent && <HeaderComponent />}
+          {!HeaderComponent && display === "inline" && (
             <View style={pickerStyles.headerFiller} />
           )}
           <View
@@ -235,28 +216,6 @@ const pickerStyles = StyleSheet.create({
   },
   containerDark: {
     backgroundColor: BACKGROUND_COLOR_DARK,
-  },
-});
-
-export const Header = ({ label, style = headerStyles }) => {
-  return (
-    <View style={style.root}>
-      <Text style={style.text}>{label}</Text>
-    </View>
-  );
-};
-
-export const headerStyles = StyleSheet.create({
-  root: {
-    borderBottomColor: BORDER_COLOR,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    padding: 14,
-    backgroundColor: "transparent",
-  },
-  text: {
-    textAlign: "center",
-    color: TITLE_COLOR,
-    fontSize: TITLE_FONT_SIZE,
   },
 });
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -79,7 +79,7 @@ export interface DateTimePickerProps {
    * Style of the backgrop (iOS)
    */
   backdropStyleIOS?: ViewStyle;
-  
+
   /**
    * Style of the modal content (iOS)
    */
@@ -150,13 +150,6 @@ export interface DateTimePickerProps {
    * Default is 'default' which shows either spinner or clock based on Android version
    */
   timePickerModeAndroid?: "spinner" | "clock" | "default";
-
-  /**
-   * Title text for the Picker on iOS
-   *
-   * Default is 'Pick a Date'
-   */
-  headerTextIOS?: string;
 
   /**
    * Minimum date the picker can go back to


### PR DESCRIPTION
<!-- Before you start, please keep in mind that the goal of this library is to be as consistent as possible with the native behaviour/style guidelines, so it's highly lickely that we won't accept contributions that introduce customization options that goes against the native guidelines. -->
# Overview

* removes deprecated `isHeaderVisibleIOS` warning:
  - removes log message in componentDidMount

* removes companion prop `headerTextIOS`
  - disposes of related constants

* removes logic checks related to `isHeaderVisibleIOS`
* refactors out default IOS header component & related constants
* updates README

Resolves: https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/606

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->  

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

**iOS**

In the example:

  1 - create a custom header component & pass as value of prop `customHeaderIOS`
  2 - choose a picker via UI 
  3 - observe your custom header!
    - additionally, please observe the header does not display when
      `customHeaderIOS` is undefined or null.

You can use this patch for testing via example:

```
diff --git a/example/App.js b/example/App.js
index fa4f0dc..6bd4565 100644
--- a/example/App.js
+++ b/example/App.js
@@ -2,6 +2,12 @@ import React, { useState } from "react";
 import { Button, Platform, StyleSheet, Switch, Text, View } from "react-native";
 import DateTimePickerModal from "react-native-modal-datetime-picker";
 
+const CustomHeaderComponent = () => (
+  <View>
+    <Text>Ahoy!</Text>
+  </View>
+);
+
 const App = () => {
   const [pickerMode, setPickerMode] = useState(null);
   const [inline, setInline] = useState(false);
@@ -44,6 +50,7 @@ const App = () => {
         mode={pickerMode}
         onConfirm={handleConfirm}
         onCancel={hidePicker}
+        customHeaderIOS={CustomHeaderComponent}
         display={inline ? "inline" : undefined}
       />
     </View>
```

# Screenshots

with `customHeaderIOS`:

![Screen Shot 2021-10-08 at 7 43 28 PM](https://user-images.githubusercontent.com/11083531/136635939-c8ed56ad-826e-4b67-bc6b-c7be4d611288.png)




without `customHeaderIOS`:

![Screen Shot 2021-10-08 at 7 50 51 PM](https://user-images.githubusercontent.com/11083531/136635943-488e10e0-c5f4-42b3-85d4-c25a8102862a.png)
