### PR TITLE
Fix TypeScript error

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -167,7 +167,7 @@ export interface DateTimePickerProps {
    *
    * @extends from DatePickerIOSProperties
    */
-  minuteInterval?: number;
+  minuteInterval?: 1 | 2 | 3 | 4 | 5 | 6 | 10 | 12 | 15 | 20 | 30;
 
   /**
    * Timezone offset in minutes.


### PR DESCRIPTION
Update minuteInterval type

# Overview

While using this library, I had the following TypeScript error:
```
No overload matches this call.
  Overload 1 of 2, '(props: ReactNativeModalDateTimePickerProps | Readonly<ReactNativeModalDateTimePickerProps>): DateTimePicker', gave the following error.
    Type '{ cancelButtonTestID?: string | undefined; confirmButtonTestID?: string | undefined; cancelTextIOS?: string | undefined; confirmTextIOS?: string | undefined; customCancelButtonIOS?: CancelButtonComponent | undefined; ... 21 more ...; onConfirm: (d: Date) => void; }' is not assignable to type 'Readonly<ReactNativeModalDateTimePickerProps>'.
      Types of property 'minuteInterval' are incompatible.
        Type 'number | undefined' is not assignable to type '2 | 1 | 3 | 4 | 5 | 6 | 10 | 12 | 15 | 20 | 30 | undefined'.
          Type 'number' is not assignable to type '2 | 1 | 3 | 4 | 5 | 6 | 10 | 12 | 15 | 20 | 30 | undefined'.
  Overload 2 of 2, '(props: ReactNativeModalDateTimePickerProps, context: any): DateTimePicker', gave the following error.
    Type '{ cancelButtonTestID?: string | undefined; confirmButtonTestID?: string | undefined; cancelTextIOS?: string | undefined; confirmTextIOS?: string | undefined; customCancelButtonIOS?: CancelButtonComponent | undefined; ... 21 more ...; onConfirm: (d: Date) => void; }' is not assignable to type 'Readonly<ReactNativeModalDateTimePickerProps>'.
      Types of property 'minuteInterval' are incompatible.
        Type 'number | undefined' is not assignable to type '2 | 1 | 3 | 4 | 5 | 6 | 10 | 12 | 15 | 20 | 30 | undefined'.ts(2769)
```

After setting the type to enum, the error was fixed.
