### PR TITLE
fix: display prop typscript issue

### DIFF
--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -248,7 +248,14 @@ export const ConfirmButton = ({
       accessibilityRole="button"
       accessibilityLabel={label}
     >
-      <Text style={[style.text, buttonTextColorIOS && { color: buttonTextColorIOS }]}>{label}</Text>
+      <Text
+        style={[
+          style.text,
+          buttonTextColorIOS && { color: buttonTextColorIOS },
+        ]}
+      >
+        {label}
+      </Text>
     </TouchableHighlight>
   );
 };
@@ -299,7 +306,14 @@ export const CancelButton = ({
       accessibilityRole="button"
       accessibilityLabel={label}
     >
-      <Text style={[style.text, buttonTextColorIOS && { color: buttonTextColorIOS }]}>{label}</Text>
+      <Text
+        style={[
+          style.text,
+          buttonTextColorIOS && { color: buttonTextColorIOS },
+        ]}
+      >
+        {label}
+      </Text>
     </TouchableHighlight>
   );
 };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -37,7 +37,7 @@ export interface DateTimePickerProps {
    * Default is '#007ff9'
    */
   buttonTextColorIOS?: string;
-  
+
   /**
    * The prop to locate cancel button for e2e testing
    */
@@ -174,7 +174,7 @@ export interface DateTimePickerProps {
    *
    * @extends from DatePickerIOSProperties
    */
-  minuteInterval?: 1 | 2 | 3 | 4 | 5 | 6 | 10 | 12 | 15 | 20 | 30;
+  minuteInterval?: 1 | 2 | 3 | 4 | 5 | 6 | 10 | 12 | 15 | 20 | 30;
 
   /**
    * Timezone offset in minutes.
@@ -216,9 +216,12 @@ export interface DateTimePickerProps {
   testID?: string;
 }
 
+type NativePickerProps =
+  | Omit<IOSNativeProps, "value" | "mode">
+  | Omit<AndroidNativeProps, "value" | "mode">;
+
 export type ReactNativeModalDateTimePickerProps = DateTimePickerProps &
-  Omit<IOSNativeProps, "value" | "mode" | "onChange"> &
-  Omit<AndroidNativeProps, "value" | "mode" | "onChange">;
+  NativePickerProps;
 
 export default class DateTimePicker extends React.Component<
   ReactNativeModalDateTimePickerProps,


### PR DESCRIPTION
<!-- Before you start, please keep in mind that the goal of this library is to be as consistent as possible with the native behaviour/style guidelines, so it's highly lickely that we won't accept contributions that introduce customization options that goes against the native guidelines. -->

# Overview
Fix for https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/567
Pulls in changes from https://github.com/mmazzarolo/react-native-modal-datetime-picker/pull/585, along with the requested changes in that PR

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->  

# Test Plan

Followed @mmazzarolo's suggestion in other PR to create a new project, add date picker, and add changes to `index.d.ts`
some screen shots below:

display options available
<img width="1069" alt="available_display_options" src="https://user-images.githubusercontent.com/12176557/160722502-a684824c-1116-49f4-b85a-e00a9e755f5a.png">

inline display option used, no ts error
<img width="1014" alt="inline_used_no_ts_error" src="https://user-images.githubusercontent.com/12176557/160722506-240ee538-3ca8-4c47-aa77-2abdd74b2c57.png">



