### PR TITLE
Adding customCancelButton and customConfirmButton types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,17 +12,68 @@ import {
   AndroidNativeProps,
 } from "@react-native-community/datetimepicker";
 
-export type CancelButtonComponent = React.ComponentType<{
-  isDarkModeEnabled: boolean;
-  onPress(): void;
-  label: string;
-}>;
+export type CancelButtonStylePropTypes = {
+  button: {
+    borderRadius: number,
+    height: number | string,
+    marginBottom: number | string,
+    justifyContent: string,
+  },
+  buttonLight: {
+    backgroundColor: string,
+  },
+  buttonDark: {
+    backgroundColor: string,
+  },
+  text: {
+    padding: number | string,
+    textAlign: string,
+    color: string,
+    fontSize: number,
+    fontWeight: string,
+    backgroundColor: string,
+  },
+};
 
-export type ConfirmButtonComponent = React.ComponentType<{
-  isDisabled: boolean;
-  onPress(): void;
-  label: string;
-}>;
+export type ConfirmButtonStylePropTypes = {
+  button: {
+    borderTopWidth: number,
+    backgroundColor: string,
+    height: number | string,
+    justifyContent: string,
+  },
+  buttonLight: {
+    borderColor: string,
+  },
+  buttonDark: {
+    borderColor: string,
+  },
+  text: {
+    textAlign: string,
+    color: string,
+    fontSize: number,
+    fontWeight: string,
+    backgroundColor: string,
+  },
+};
+
+export type CancelButtonPropTypes = {
+  isDarkModeEnabled?: boolean,
+  cancelButtonTestID?: string,
+  onPress: () => void,
+  label: string,
+  buttonTextColorIOS?: string,
+  style?: CancelButtonStylePropTypes,
+};
+
+export type ConfirmButtonPropTypes = {
+  isDarkModeEnabled?: boolean,
+  confirmButtonTestID?: string,
+  onPress: () => void,
+  label: string,
+  buttonTextColorIOS?: string,
+  style?: ConfirmButtonStylePropTypes,
+};
 
 export type HeaderComponent = React.ComponentType<{
   label: string;
@@ -65,12 +116,12 @@ export interface DateTimePickerProps {
   /**
    * A custom component for the cancel button on iOS
    */
-  customCancelButtonIOS?: CancelButtonComponent;
+  customCancelButtonIOS?: React.FunctionComponent<CancelButtonPropTypes>;
 
   /**
    * A custom component for the confirm button on iOS
    */
-  customConfirmButtonIOS?: ConfirmButtonComponent;
+  customConfirmButtonIOS?: React.FunctionComponent<ConfirmButtonPropTypes>;
 
   /**
    * A custom component for the title container on iOS
@@ -232,3 +283,11 @@ export default class DateTimePicker extends React.Component<
   ReactNativeModalDateTimePickerProps,
   any
 > {}
+
+export class CancelButton extends React.Component<CancelButtonPropTypes> {}
+
+export class ConfirmButton extends React.Component<ConfirmButtonPropTypes> {}
+
+export const cancelButtonStyles: CancelButtonStylePropTypes;
+
+export const confirmButtonStyles: ConfirmButtonStylePropTypes;


### PR DESCRIPTION
Thank you guys for an amazing lib!!

# Overview

The library is missing the `CancelButton` and `ConfirmButton` components for the iOS only properties `customCancelButtonIOS` and `customConfirmButtonIOS`. I also found a good idea to export their styles, just in case someone (myself included) wants to do some slight changes.

All I mentioned works fine, but whenever you try to import any of these two components or their styles you get some red on your code editor. That's because the declaration file is missing these elements. So all I did was I exported from  `ìndex.d.ts` the `CancelButton` and `ConfirmButton` components, told the declaration file the `customConfirmButtonIOS` and `customCancelButtonIOS` properties were a `React.FunctionComponenet<props>` with some extra props. I also exported the style types of both components.

# Test Plan

There is not much to do actually, all I did was passing the `buttonTextColorIOS` property to the custom button I was using. For example:

```javascript
import ModalDateTimePicker, { CancelButton };

<ModalDateTimePicker
    // ... <normally used props>
    customCancelButtonIOS={(props) => <CancelButton {...props} buttonTextColorIOS="red"  />}
/>
```

If you want to change the button styles, you might want to do something like that:

```javascript
import ModalDateTimePicker, { CancelButton, CancelButtonStylePropTypes, cancelButtonStyles };

const customStyles: CancelButtonStylePropTypes = {
    ...cancelButtonStyles,
    text: {
        ...cancelButtonStyles.text,
        color: 'red',
    },
};

<ModalDateTimePicker
    // ... <normally used props>
    customCancelButtonIOS={(props) => <CancelButton {...props} style={customStyles} />}
/>
```
