### PR TITLE
Fix deviceEventEmitter is undefined crash when screen will unmount

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -50,7 +50,7 @@ export class Modal extends Component {
   }
 
   componentWillUnmount() {
-    this._deviceEventEmitter.remove();
+    this._deviceEventEmitter?.remove();
     this._isMounted = false;
   }
 


### PR DESCRIPTION
When navigating away from the screen with datetime-picker modal, the app crashes with property is undefined error. Crash occured after upgrading to react native 0.70.2.