### PR TITLE
fix: omitted underlying onChange prop type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -285,8 +285,8 @@ export interface DateTimePickerProps {
 }
 
 type NativePickerProps =
-  | Omit<IOSNativeProps, "value" | "mode">
-  | Omit<AndroidNativeProps, "value" | "mode">;
+  | Omit<IOSNativeProps, "value" | "mode" | "onChange">
+  | Omit<AndroidNativeProps, "value" | "mode" | "onChange">;
 
 export type ReactNativeModalDateTimePickerProps = DateTimePickerProps &
   NativePickerProps;


### PR DESCRIPTION
<!-- Before you start, please keep in mind that the goal of this library is to be as consistent as possible with the native behaviour/style guidelines, so it's highly lickely that we won't accept contributions that introduce customization options that goes against the native guidelines. -->

# Overview

The prop onChange was being interpreted as an union between the onChange prop of this library and the onChange prop of `@react-native-community/datetimepicker`. I ommited this key because Typescript was expecting a callback with two params (event, date) instead of just one as this library says it should receive (only date).

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change --> 