### PR TITLE
Fix - using the new useWindowDimensions api to fix unmounting issues

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -77,7 +77,7 @@ const Modal = ({
         toValue: 1,
       }).start();
     } else if (visibility) {
-      Animated.timing(this.animVal, {
+      Animated.timing(animVal, {
         easing: Easing.inOut(Easing.quad),
         // Using native driver in the modal makes the content flash
         useNativeDriver: false,

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import {
   Animated,
@@ -11,128 +11,6 @@ import {
 
 const MODAL_ANIM_DURATION = 300;
 const MODAL_BACKDROP_OPACITY = 0.4;
-
-export class Modal extends Component {
-  static propTypes = {
-    onBackdropPress: PropTypes.func,
-    onHide: PropTypes.func,
-    isVisible: PropTypes.bool,
-    contentStyle: PropTypes.any,
-  };
-
-  static defaultProps = {
-    onBackdropPress: () => null,
-    onHide: () => null,
-    isVisible: false,
-  };
-
-  state = {
-    isVisible: this.props.isVisible,
-  };
-
-  animVal = new Animated.Value(0);
-  _isMounted = false;
-
-  componentDidMount() {
-    this._isMounted = true;
-    if (this.state.isVisible) {
-      this.show();
-    }
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false;
-  }
-
-  componentDidUpdate(prevProps: ModalPropsType) {
-    if (this.props.isVisible && !prevProps.isVisible) {
-      this.show();
-    } else if (!this.props.isVisible && prevProps.isVisible) {
-      this.hide();
-    }
-  }
-
-  show = () => {
-    this.setState({ isVisible: true });
-    Animated.timing(this.animVal, {
-      easing: Easing.inOut(Easing.quad),
-      // Using native driver in the modal makes the content flash
-      useNativeDriver: false,
-      duration: MODAL_ANIM_DURATION,
-      toValue: 1,
-    }).start();
-  };
-
-  hide = () => {
-    Animated.timing(this.animVal, {
-      easing: Easing.inOut(Easing.quad),
-      // Using native driver in the modal makes the content flash
-      useNativeDriver: false,
-      duration: MODAL_ANIM_DURATION,
-      toValue: 0,
-    }).start(() => {
-      if (this._isMounted) {
-        this.setState({ isVisible: false }, this.props.onHide);
-      }
-    });
-  };
-
-  render() {
-    const {
-      children,
-      onBackdropPress,
-      contentStyle,
-      backdropStyle,
-      ...otherProps
-    } = this.props;
-    const { isVisible } = this.state;
-    const { height, width } = useWindowDimensions();
-    const backdropAnimatedStyle = {
-      opacity: this.animVal.interpolate({
-        inputRange: [0, 1],
-        outputRange: [0, MODAL_BACKDROP_OPACITY],
-      }),
-    };
-    const contentAnimatedStyle = {
-      transform: [
-        {
-          translateY: this.animVal.interpolate({
-            inputRange: [0, 1],
-            outputRange: [height, 0],
-            extrapolate: "clamp",
-          }),
-        },
-      ],
-    };
-    return (
-      <ReactNativeModal
-        transparent
-        animationType="none"
-        visible={isVisible}
-        {...otherProps}
-      >
-        <TouchableWithoutFeedback onPress={onBackdropPress}>
-          <Animated.View
-            style={[
-              styles.backdrop,
-              backdropAnimatedStyle,
-              { width, height },
-              backdropStyle,
-            ]}
-          />
-        </TouchableWithoutFeedback>
-        {isVisible && (
-          <Animated.View
-            style={[styles.content, contentAnimatedStyle, contentStyle]}
-            pointerEvents="box-none"
-          >
-            {children}
-          </Animated.View>
-        )}
-      </ReactNativeModal>
-    );
-  }
-}
 
 const styles = StyleSheet.create({
   container: {
@@ -156,5 +34,132 @@ const styles = StyleSheet.create({
     justifyContent: "flex-end",
   },
 });
+
+const Modal = ({
+  backdropStyle,
+  children,
+  contentStyle,
+  isVisible,
+  onBackdropPress,
+  onHide,
+  ...otherProps
+}) => {
+  const animVal = new Animated.Value(0);
+  const { state, setState } = useState({
+    isVisible: isVisible,
+    isMounted: false,
+  });
+  const { height, width } = useWindowDimensions();
+  const backdropAnimatedStyle = {
+    opacity: animVal.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, MODAL_BACKDROP_OPACITY],
+    }),
+  };
+  const contentAnimatedStyle = {
+    transform: [
+      {
+        translateY: animVal.interpolate({
+          inputRange: [0, 1],
+          outputRange: [height, 0],
+          extrapolate: "clamp",
+        }),
+      },
+    ],
+  };
+
+  useEffect(() => {
+    setState({
+      ...state,
+      isMounted: true,
+    });
+    if (state.isVisible) {
+      setState({ isVisible: true });
+      Animated.timing(animVal, {
+        easing: Easing.inOut(Easing.quad),
+        // Using native driver in the modal makes the content flash
+        useNativeDriver: false,
+        duration: MODAL_ANIM_DURATION,
+        toValue: 1,
+      }).start();
+    }
+
+    return () => {
+      setState({
+        ...state,
+        isMounted: false,
+      });
+    };
+    // eslint-disable-next-line react-app/react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (isVisible) {
+      setState({ isVisible: true });
+      Animated.timing(animVal, {
+        easing: Easing.inOut(Easing.quad),
+        // Using native driver in the modal makes the content flash
+        useNativeDriver: false,
+        duration: MODAL_ANIM_DURATION,
+        toValue: 1,
+      }).start();
+    } else if (!isVisible) {
+      Animated.timing(this.animVal, {
+        easing: Easing.inOut(Easing.quad),
+        // Using native driver in the modal makes the content flash
+        useNativeDriver: false,
+        duration: MODAL_ANIM_DURATION,
+        toValue: 0,
+      }).start(() => {
+        if (state.isMounted) {
+          setState({ isVisible: false }, onHide);
+        }
+      });
+    }
+    // eslint-disable-next-line react-app/react-hooks/exhaustive-deps
+  }, [isVisible]);
+
+  return (
+    <ReactNativeModal
+      transparent
+      animationType="none"
+      visible={state.isVisible}
+      {...otherProps}
+    >
+      <TouchableWithoutFeedback onPress={onBackdropPress}>
+        <Animated.View
+          style={[
+            styles.backdrop,
+            backdropAnimatedStyle,
+            { width, height },
+            backdropStyle,
+          ]}
+        />
+      </TouchableWithoutFeedback>
+      {state.isVisible && (
+        <Animated.View
+          style={[styles.content, contentAnimatedStyle, contentStyle]}
+          pointerEvents="box-none"
+        >
+          {children}
+        </Animated.View>
+      )}
+    </ReactNativeModal>
+  );
+};
+
+Modal.propTypes = {
+  onBackdropPress: PropTypes.func,
+  onHide: PropTypes.func,
+  isVisible: PropTypes.bool,
+  contentStyle: PropTypes.any,
+};
+
+Modal.defaultProps = {
+  onBackdropPress: () => null,
+  onHide: () => null,
+  isVisible: false,
+  contentStyle: {},
+};
 
 export default Modal;

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -2,12 +2,11 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import {
   Animated,
-  DeviceEventEmitter,
-  Dimensions,
   Easing,
   Modal as ReactNativeModal,
   StyleSheet,
   TouchableWithoutFeedback,
+  useWindowDimensions,
 } from "react-native";
 
 const MODAL_ANIM_DURATION = 300;
@@ -29,28 +28,19 @@ export class Modal extends Component {
 
   state = {
     isVisible: this.props.isVisible,
-    deviceWidth: Dimensions.get("window").width,
-    deviceHeight: Dimensions.get("window").height,
   };
 
   animVal = new Animated.Value(0);
   _isMounted = false;
-
-  static _deviceEventEmitter = null;
 
   componentDidMount() {
     this._isMounted = true;
     if (this.state.isVisible) {
       this.show();
     }
-    this._deviceEventEmitter = DeviceEventEmitter.addListener(
-      "didUpdateDimensions",
-      this.handleDimensionsUpdate
-    );
   }
 
   componentWillUnmount() {
-    this._deviceEventEmitter.remove();
     this._isMounted = false;
   }
 
@@ -61,17 +51,6 @@ export class Modal extends Component {
       this.hide();
     }
   }
-
-  handleDimensionsUpdate = (dimensionsUpdate) => {
-    const deviceWidth = dimensionsUpdate.window.width;
-    const deviceHeight = dimensionsUpdate.window.height;
-    if (
-      deviceWidth !== this.state.deviceWidth ||
-      deviceHeight !== this.state.deviceHeight
-    ) {
-      this.setState({ deviceWidth, deviceHeight });
-    }
-  };
 
   show = () => {
     this.setState({ isVisible: true });
@@ -106,7 +85,8 @@ export class Modal extends Component {
       backdropStyle,
       ...otherProps
     } = this.props;
-    const { deviceHeight, deviceWidth, isVisible } = this.state;
+    const { isVisible } = this.state;
+    const { height, width } = useWindowDimensions();
     const backdropAnimatedStyle = {
       opacity: this.animVal.interpolate({
         inputRange: [0, 1],
@@ -118,7 +98,7 @@ export class Modal extends Component {
         {
           translateY: this.animVal.interpolate({
             inputRange: [0, 1],
-            outputRange: [deviceHeight, 0],
+            outputRange: [height, 0],
             extrapolate: "clamp",
           }),
         },
@@ -136,7 +116,7 @@ export class Modal extends Component {
             style={[
               styles.backdrop,
               backdropAnimatedStyle,
-              { width: deviceWidth, height: deviceHeight },
+              { width, height },
               backdropStyle,
             ]}
           />

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -90,7 +90,7 @@ const Modal = ({
         }
       });
     }
-  }, [visibility]);
+  }, [animVal, onHide, visibility]);
 
   return (
     <ReactNativeModal

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -90,7 +90,6 @@ const Modal = ({
         }
       });
     }
-    // eslint-disable-next-line react-app/react-hooks/exhaustive-deps
   }, [visibility]);
 
   return (


### PR DESCRIPTION
# Overview

Unmounting causes issues with the removal of the event listener so I have used the new useWindowDimensions hook to remove the need for a listener all together as the height and width are got dynamically now.

# Test Plan

I ran yarn lint and prettify for code structure testing and tested the modal works on differing screen sizes using android studio.
