### PR TITLE
fix: Remove date parameter from onCancel

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -269,9 +269,8 @@ export interface DateTimePickerProps {
 
   /**
    * Handler called when the user presses the cancel button
-   * Passes the current selected date
    */
-  onCancel(date: Date): void;
+  onCancel(): void;
 
   /**
    * Called when the underlying modal finishes its' closing animation


### PR DESCRIPTION
<!-- Before you start, please keep in mind that the goal of this library is to be as consistent as possible with the native behaviour/style guidelines, so it's highly lickely that we won't accept contributions that introduce customization options that goes against the native guidelines. -->

# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->  

As discussed in #709 onCancel does not have any parameters. This pull request corrects the typings to reflect this

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

Compiles successfully 
