### PR TITLE
fix: swap ios button style, closes #689

### DIFF
--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -318,7 +318,7 @@ export const CancelButton = ({
   return (
     <TouchableHighlight
       testID={cancelButtonTestID}
-      style={[style.button, themedButtonStyle]}
+      style={[themedButtonStyle, style.button]}
       underlayColor={underlayColor}
       onPress={onPress}
       accessible={true}


### PR DESCRIPTION
<!-- Before you start, please keep in mind that the goal of this library is to be as consistent as possible with the native behaviour/style guidelines, so it's highly lickely that we won't accept contributions that introduce customization options that goes against the native guidelines. -->

# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->  

Swap the button style on iOS as suggested on #689 

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

The order of style on cancel button is the same as confirm button.
