### PR TITLE
Support iPhone 14 Pro & Pro Max safe area bottom inset

### DIFF
--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -221,7 +221,7 @@ const pickerStyles = StyleSheet.create({
   modal: {
     justifyContent: "flex-end",
     margin: 10,
-    marginBottom: isIphoneX() ? 30 : 10,
+    marginBottom: isIphoneX() ? 34 : 10,
   },
   container: {
     borderRadius: BORDER_RADIUS,

--- a/src/DateTimePickerModal.ios.js
+++ b/src/DateTimePickerModal.ios.js
@@ -221,6 +221,7 @@ const pickerStyles = StyleSheet.create({
   modal: {
     justifyContent: "flex-end",
     margin: 10,
+    marginBottom: isIphoneX() ? 30 : 10,
   },
   container: {
     borderRadius: BORDER_RADIUS,
@@ -341,7 +342,6 @@ export const cancelButtonStyles = StyleSheet.create({
   button: {
     borderRadius: BORDER_RADIUS,
     height: 57,
-    marginBottom: isIphoneX() ? 20 : 0,
     justifyContent: "center",
   },
   buttonLight: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,9 +13,13 @@ export const isIphoneX = () => {
       width === 812 ||
       height === 844 ||
       width === 844 ||
+      height === 852 ||
+      width === 852 ||
       height === 896 ||
       width === 896 ||
       height === 926 ||
-      width === 926)
+      width === 926 ||
+      height === 932 ||
+      width === 932)
   );
 };


### PR DESCRIPTION
<!-- Before you start, please keep in mind that the goal of this library is to be as consistent as possible with the native behaviour/style guidelines, so it's highly lickely that we won't accept contributions that introduce customization options that goes against the native guidelines. -->

# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->  

- Added missing iPhone 14 Pro & iPhone 14 Pro Max dimensions to the `isIphoneX()` method.
- The `marginBottom` is applied to `modal` styles rather than the cancel button styles. This allows overriding the bottom margin through `modalStyleIOS`.
- The margin value is updated to `34pt` which is the proper size of the iOS bottom inset. Reference: [iPhone 14 Screen Sizes](https://useyourloaf.com/blog/iphone-14-screen-sizes/)

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

The bottom inset of 34pt should appear for iPhone 14 Pro and iPhone 14 Pro Max. Users should be able to manually update the inset value through `modalStyleIOS` prop.
