### PR TITLE
fix: Wrong onHide signature

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -274,9 +274,9 @@ export interface DateTimePickerProps {
 
   /**
    * Called when the underlying modal finishes its' closing animation
-   * after Confirm was pressed.
+   * after Confirm or Cancel was pressed.
    */
-  onHide?(date: Date): void;
+  onHide?(didPressConfirm: boolean, currentDate?: Date): void;
 
   /**
    * Used to locate this view in end-to-end tests.


### PR DESCRIPTION
Fixing: https://github.com/mmazzarolo/react-native-modal-datetime-picker/issues/735

This change does not introduce new behaviour or functionality but simply corrects the TypeScript definition to align with existing behaviour.

Previously, the onHide prop's TypeScript definition accepted a single Date parameter, representing the selected date when the modal is dismissed. However, the actual implementation passes two parameters: a boolean indicating whether the Confirm button was pressed, and a Date object if the Confirm button was pressed. The updated TypeScript definition now accurately reflects this functionality.

Test Plan

Confirm Button Press:
- Open the date-time picker.
- Select a date and press the Confirm button.
- Ensure that onHide is called with didPressConfirm set to true and currentDate reflecting the selected date.

Cancel Button Press:
- Open the date-time picker.
- Press the Cancel button without selecting a date.
- Ensure that onHide is called with didPressConfirm set to false, and currentDate is undefined.
